### PR TITLE
Change behaviour to not modify metadata object in merge function

### DIFF
--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -197,7 +197,7 @@ export function mergeMetadata(key: DecoratorKeys, value: unknown, cl: new () => 
     throw new NoValidClass(cl);
   }
 
-  const current = Reflect.getMetadata(key, cl) || {};
+  const current = Object.assign({}, Reflect.getMetadata(key, cl) || {});
 
   if (isNullOrUndefined(value)) {
     return current;

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -162,6 +162,13 @@ export function suite() {
     expect(mergeMetadata(DecoratorKeys.ModelOptions, undefined, Dummy))
       .to.deep.equal({ schemaOptions: { _id: false } });
   });
+  it('should not modify current metadata object in "mergeMetadata"', () => {
+    class Dummy {}
+    const someData = { property: 'value' };
+    Reflect.defineMetadata(DecoratorKeys.ModelOptions, someData, Dummy);
+    mergeMetadata(DecoratorKeys.ModelOptions, { schemaOptions: { _id: false } }, Dummy);
+    expect(someData).to.deep.equal({ property: 'value' });
+  });
 
   it('should just run with an non existing value in "mergeSchemaOptions"', () => {
     class Dummy { }
@@ -173,18 +180,16 @@ export function suite() {
     @modelOptions({ schemaOptions: { timestamps: true, _id: false } })
     class TestAssignMetadata { }
 
-    getModelForClass(TestAssignMetadata, {
-      // @ts-ignore
-      testOption: 'hello',
-      schemaOptions: { _id: true }
+    const model = getModelForClass(TestAssignMetadata, {
+      schemaOptions: {
+        _id: true,
+        // @ts-ignore
+        testOption: 'hello'}
     });
 
-    const reflected = Reflect.getMetadata(DecoratorKeys.ModelOptions, TestAssignMetadata);
-
-    expect(reflected).to.not.be.an('undefined');
-    expect(reflected).to.have.property('testOption', 'hello');
-    expect(reflected.schemaOptions).to.have.property('timestamps', true);
-    expect(reflected.schemaOptions).to.have.property('_id', true);
+    expect(model.schema.options).to.have.property('testOption', 'hello');
+    expect(model.schema.options).to.have.property('timestamps', true);
+    expect(model.schema.options).to.have.property('_id', true);
   });
 
   it('should make use of "@prop({ _id: false })" and have no _id', async () => {

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -163,7 +163,7 @@ export function suite() {
       .to.deep.equal({ schemaOptions: { _id: false } });
   });
   it('should not modify current metadata object in "mergeMetadata"', () => {
-    class Dummy {}
+    class Dummy { }
     const someData = { property: 'value' };
     Reflect.defineMetadata(DecoratorKeys.ModelOptions, someData, Dummy);
     mergeMetadata(DecoratorKeys.ModelOptions, { schemaOptions: { _id: false } }, Dummy);
@@ -183,8 +183,9 @@ export function suite() {
     const model = getModelForClass(TestAssignMetadata, {
       schemaOptions: {
         _id: true,
-        // @ts-ignore
-        testOption: 'hello'}
+        // @ts-ignore because it is only there for tests and dosnt exists on type "SchemaOptions" (from mongoose)
+        testOption: 'hello'
+      }
     });
 
     expect(model.schema.options).to.have.property('testOption', 'hello');


### PR DESCRIPTION
Fixes a bug with different options for the same model. 
The `mergeMetadata` function modified the current metadata instead of returning a modified copy.