### PR TITLE
DOC: fix some minor documentation quirks

### DIFF
--- a/github-page/_guides/advanced/models-with-same-name.md
+++ b/github-page/_guides/advanced/models-with-same-name.md
@@ -60,4 +60,4 @@ expect(model.modelName).to.be.equal('CustomName');
 
 ---
 
-For more a more detailed use, please look into the code at [the tests that are written for it](https://github.com/hasezoey/typegoose/blob/master/test/tests/options.test.ts)
+For more a more detailed use, please look into the code at [the tests that are written for it](https://github.com/typegoose/typegoose/blob/r6/master/test/tests/customName.test.ts)

--- a/github-page/_guides/quick-start-guide.md
+++ b/github-page/_guides/quick-start-guide.md
@@ -110,11 +110,11 @@ class KittenClass {
 
 const Kitten = getModelForClass(KittenClass);
 
-let document = await Kitten.create({ name: 'Kitty' });
+let document = new Kitten({ name: 'Kitty' });
 // "document" has types of KittenClass
 ```
 
-Please note that `new Kitten({})` or `await Kitten.create({})` has no types of KittenClass, because typegoose dosnt modify functions of mongoose
+Please note that `await Kitten.create({})` has no types of KittenClass, because typegoose doesn't modify functions of mongoose
 
 ## Do's and Dont's of Typegoose
 
@@ -122,3 +122,7 @@ Please note that `new Kitten({})` or `await Kitten.create({})` has no types of K
 - Typegoose aims to not modify any functions of mongoose
 - Typegoose aims to get mongoose's models to be stable through type-infomation
 - Typegoose aims to make mongoose more usable by making the models more type-rich (thanks to TypeScript)
+- Decorated schema configuration classes (like KittenClass above) must use explicit type declaration
+instead of type inference for their types.  Otherwise, a property's type will become Mixed!  This is
+because Typegoose uses emitDecoratorMetadata to determine types, and by design, emitDecorator emits the
+explicit type instead of what's inferred (see https://github.com/microsoft/TypeScript/issues/18995).

--- a/github-page/_guides/quick-start-guide.md
+++ b/github-page/_guides/quick-start-guide.md
@@ -110,11 +110,11 @@ class KittenClass {
 
 const Kitten = getModelForClass(KittenClass);
 
-let document = new Kitten({ name: 'Kitty' });
+let document = await Kitten.create({ name: 'Kitty' });
 // "document" has types of KittenClass
 ```
 
-Please note that `await Kitten.create({})` has no types of KittenClass, because typegoose doesn't modify functions of mongoose
+Please note that `new Kitten({})` & `await Kitten.create({})` has no types of KittenClass, because typegoose doesn't modify functions of mongoose
 
 ## Do's and Dont's of Typegoose
 
@@ -125,4 +125,4 @@ Please note that `await Kitten.create({})` has no types of KittenClass, because 
 - Decorated schema configuration classes (like KittenClass above) must use explicit type declaration
 instead of type inference for their types.  Otherwise, a property's type will become Mixed!  This is
 because Typegoose uses emitDecoratorMetadata to determine types, and by design, emitDecorator emits the
-explicit type instead of what's inferred (see https://github.com/microsoft/TypeScript/issues/18995).
+explicit type instead of what's inferred (see [microsoft/Typegoose#18995](https://github.com/microsoft/TypeScript/issues/18995)).


### PR DESCRIPTION
## Adds Documentation for

- temporarily move broken link to tests to r6 branch link
- fix minor typo in quick start guide about new vs create
- add minor gotcha to quick start guide about inferred types
