### PR TITLE
Fix decorator options mutating (fixes #55)

### DIFF
--- a/src/prop.ts
+++ b/src/prop.ts
@@ -53,13 +53,14 @@ function baseProp(
   const initname = utils.createUniqueID(target);
 
   decoratorCache.get(initname).decorators.set(key, () => {
+    const rawOptions = Object.assign({}, origOptions);
+
     if (utils.isNotDefined(Type)) {
       if (Type !== target) { // prevent "infinite" buildSchema loop / Maximum Class size exceeded
-        buildSchema(Type, { _id: typeof origOptions._id === 'boolean' ? origOptions._id : true });
+        buildSchema(Type, { _id: typeof rawOptions._id === 'boolean' ? rawOptions._id : true });
       }
     }
     const name: string = utils.getName(target.constructor);
-    const rawOptions = Object.assign({}, origOptions);
 
     if (!virtuals.get(name)) {
       virtuals.set(name, new Map());

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -32,14 +32,14 @@ enum WhatIsIt {
 
 /**
  * Base Function for prop & arrayProp
- * @param rawOptions The options (like require)
+ * @param origOptions The options (like require)
  * @param Type What Type it is
  * @param target Target Class
  * @param key Value Key of target class
  * @param isArray is it an array?
  */
 function baseProp(
-  rawOptions: any,
+  origOptions: any,
   Type: AnyParamConstructor<any>,
   target: any,
   key: string,
@@ -55,11 +55,11 @@ function baseProp(
   decoratorCache.get(initname).decorators.set(key, () => {
     if (utils.isNotDefined(Type)) {
       if (Type !== target) { // prevent "infinite" buildSchema loop / Maximum Class size exceeded
-        buildSchema(Type, { _id: typeof rawOptions._id === 'boolean' ? rawOptions._id : true });
+        buildSchema(Type, { _id: typeof origOptions._id === 'boolean' ? origOptions._id : true });
       }
     }
     const name: string = utils.getName(target.constructor);
-    rawOptions = Object.assign(rawOptions, {});
+    const rawOptions = Object.assign({}, origOptions);
 
     if (!virtuals.get(name)) {
       virtuals.set(name, new Map());


### PR DESCRIPTION
When a class has n properties using the same subclass, the
function `baseProp` is called n times for each property in subclass.

The function `baseProp` receives a parameter `rawOptions` which
should be copied as its being mutated later on. This is intended with
the statement:
```
rawOptions = Object.assign(rawOptions, {})
```
Although, this statement never changes the reference of `rawOptions`
with as result that the options are mutating. This causes the final schema
to be constructed without the options ref, itemsRef, refPath, etc when
the subclass is used more than once.

This commit fixes the mutation of the options.

Signed-off-by: Chris Lahaye <dev@chrislahaye.com>
