### PR TITLE
Upgrade to Typescript 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js: [
   # check Latest
+  13,
   12,
   # check LTS
   10,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "prettier.printWidth": 140,
     "editor.wordWrapColumn": 140,
     "editor.tabSize": 2,
-    "editor.insertSpaces": true
+    "editor.insertSpaces": true,
+    "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ class User {
 
 ## Requirements
 
-* TypeScript 3.2+
+* TypeScript 3.7+
 * Node 8.10+
 * mongoose ^5.7.7
 * `emitDecoratorMetadata` and `experimentalDecorators` must be enabled in `tsconfig.json`

--- a/github-page/_guides/quick-start-guide.md
+++ b/github-page/_guides/quick-start-guide.md
@@ -79,9 +79,9 @@ class User {
 
 ### Requirements
 
-- TypeScript 3.2+
+- TypeScript 3.7+
 - NodeJS 8.10.0+
-- Mongoose 5.6.9+
+- Mongoose 5.7.7+
 - An IDE that supports TypeScript linting (VSCode is recommendet)
 - This Guide expect you to know how mongoose (at least its models) work
 

--- a/github-page/changelog.md
+++ b/github-page/changelog.md
@@ -14,21 +14,28 @@ redirect_from:
 <sub>This Version is not yet released, only changes made until now are listed here</sub>
 ETA: 5~7th November
 
+- Update Dependencies
+  - Upgrade mongoose from 5.7.1 to 5.7.8
+  - [IC] Upgrade Typescript from 3.6.x to 3.7.2
+  - [IC] Upgrade @types/node from 8.10.53 to 12.12.5 (typescript should still compile everything down to Node 8.10+)
 - Completly remove `@staticMethod` & `@instanceMethod`, because they were completly obsolete
 - README now has no documentation anymore
 - `@prop({ validate })` now accepts `{ validator, message }` as an array
-- Add function "deleteModel" & "deleteModelWithClass"
+- Add function `deleteModel` & `deleteModelWithClass`
 - allow Prop Option "type" to overwrite the inferred type [look here for an example](https://typegoose.github.io/typegoose/docs/decorators/prop/#type)
 - integrate "Array Validators & Transform" tests {% include gitissue repo="typegoose" num=29 %}
 - adding global options, with `setGlobalOptions`
 - add modelOption `runSyncIndexes`
 - add modelOption `allowMixed`
 - add `text` to PropOptions
-- deprecate ArrayPropOptions's "itemsRef", "itemsRefPath" & "itemsRefType"
+- deprecate ArrayPropOptions's `itemsRef`, `itemsRefPath` & `itemsRefType`
 - `DocumentType` will now overwrite the type of `_id` if the class is extending `Base` (in typescript there is currently no other way)
 - add `tslib` as dependencie to minimize generated code
 - fixing typo in (deprecated) `setModelForClass`
 - Remake how Enums are handeled, use `setGlobalOptions({ globalOptions: { useNewEnum: true } })` (to not break existing databases made with the old handling)
+- [IC] combine `initAsObject` and `initAsArray` into `initProperty`
+- [IC] Use internal "isNullOrUndefined", needed because all "util.is*" functions got deprecated in node 4.0.0
+- [IC] Replace all "isArray" with "Array.isArray", needed because all "util.is*" functions got deprecated in node 4.0.0
 - [IC] adding many sanity `isNullOrUndefined` checks
 - [IC] Re-done how the handling of `Mixed` is done
 - [IC] Re-done how `IModelOptions` are merged (thanks to lodash `cloneDeepWith` & `mergeWith`)

--- a/github-page/changelog.md
+++ b/github-page/changelog.md
@@ -17,7 +17,6 @@ ETA: 5~7th November
 - Update Dependencies
   - Upgrade mongoose from 5.7.1 to 5.7.8
   - [IC] Upgrade Typescript from 3.6.x to 3.7.2
-  - [IC] Upgrade @types/node from 8.10.53 to 12.12.5 (typescript should still compile everything down to Node 8.10+)
 - Completly remove `@staticMethod` & `@instanceMethod`, because they were completly obsolete
 - README now has no documentation anymore
 - `@prop({ validate })` now accepts `{ validator, message }` as an array

--- a/github-page/index.md
+++ b/github-page/index.md
@@ -20,9 +20,9 @@ feature_row:
     btn_class: "btn--primary"
     btn_label: "Learn more"
   # - image_path: /assets/images/unkown.png
-  - alt: "idk what alt"
+  - alt: "Latest Verions"
     title: "Latest Verions"
-    excerpt: "Built with TypeScript 3.6"
+    excerpt: "Built with TypeScript 3.7"
     url: "/guides/quick-start-guide/"
     btn_class: "btn--primary"
     btn_label: "Learn more"

--- a/package-lock.json
+++ b/package-lock.json
@@ -197,9 +197,9 @@
       }
     },
     "@types/node": {
-      "version": "12.12.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.5.tgz",
-      "integrity": "sha512-KEjODidV4XYUlJBF3XdjSH5FWoMCtO0utnhtdLf1AgeuZLOrRbvmU/gaRCVg7ZaQDjVf3l84egiY0mRNe5xE4A==",
+      "version": "8.10.58",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.58.tgz",
+      "integrity": "sha512-NNcUk/rAdR7Pie7WiA5NHp345dTkD62qaxqscQXVIjCjog/ZXsrG8Wo7dZMZAzE7PSpA+qR2S3TYTeFCKuBFxQ==",
       "dev": true
     },
     "@types/semver": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/lodash": "^4.14.144",
     "@types/mocha": "^5.2.7",
     "@types/mongoose": "^5.5.29",
-    "@types/node": "^12.12.5",
+    "@types/node": "^8.10.53",
     "@types/semver": "^6.2.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/src/defaultClasses.ts
+++ b/src/defaultClasses.ts
@@ -1,4 +1,5 @@
 import { Types } from 'mongoose';
+
 import { modelOptions } from './optionsProp';
 import { DocumentType, RefType } from './types';
 

--- a/src/globalOptions.ts
+++ b/src/globalOptions.ts
@@ -1,3 +1,5 @@
+import * as assert from 'assert';
+
 import { globalOptions } from './internal/data';
 import { logger } from './logSettings';
 import { IGlobalOptions } from './types';
@@ -6,9 +8,7 @@ import { IGlobalOptions } from './types';
  * Set Typegoose's global Options
  */
 export function setGlobalOptions(options: IGlobalOptions) {
-  if (typeof options !== 'object') {
-    throw new TypeError('"options" argument needs to be an object!');
-  }
+  assert(typeof options === 'object', new TypeError('"options" argument needs to be an object!'));
 
   logger.info('"setGlobalOptions" got called with', options);
 

--- a/src/globalOptions.ts
+++ b/src/globalOptions.ts
@@ -1,5 +1,3 @@
-import * as assert from 'assert';
-
 import { globalOptions } from './internal/data';
 import { logger } from './logSettings';
 import { IGlobalOptions } from './types';
@@ -8,7 +6,9 @@ import { IGlobalOptions } from './types';
  * Set Typegoose's global Options
  */
 export function setGlobalOptions(options: IGlobalOptions) {
-  assert(typeof options === 'object', new TypeError('"options" argument needs to be an object!'));
+  if (typeof options !== 'object') {
+    throw new TypeError('"options" argument needs to be an object!');
+  }
 
   logger.info('"setGlobalOptions" got called with', options);
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,4 +1,6 @@
+import * as assert from 'assert';
 import { Query } from 'mongoose';
+
 import { hooks as hooksData, IHooks } from './internal/data';
 import { getName } from './internal/utils';
 import { DocumentType } from './typegoose';
@@ -87,7 +89,7 @@ const hooks: Hooks = {
  * @param args All Arguments, that should be passed-throught
  */
 function addToHooks(name: string, hookType: 'pre' | 'post', args: any[]) {
-  if (!hooksData.get(name)) {
+  if (!hooksData.has(name)) {
     hooksData.set(name, {
       post: [],
       pre: []
@@ -96,9 +98,7 @@ function addToHooks(name: string, hookType: 'pre' | 'post', args: any[]) {
 
   // Convert Method to array if only a string is provided
   const methods: QDM[] = Array.isArray(args[0]) ? args[0] : [args[0]];
-  if (typeof args[1] !== 'function') {
-    throw new TypeError(`"${name}.${hookType}.${methods.join(' ')}"'s function is not a function!`);
-  }
+  assert(typeof args[1] === 'function', new TypeError(`"${name}.${hookType}.${methods.join(' ')}"'s function is not a function!`));
   const func: EmptyVoidFn = args[1];
 
   for (const method of methods) {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,4 +1,3 @@
-import * as assert from 'assert';
 import { Query } from 'mongoose';
 
 import { hooks as hooksData, IHooks } from './internal/data';
@@ -98,7 +97,9 @@ function addToHooks(name: string, hookType: 'pre' | 'post', args: any[]) {
 
   // Convert Method to array if only a string is provided
   const methods: QDM[] = Array.isArray(args[0]) ? args[0] : [args[0]];
-  assert(typeof args[1] === 'function', new TypeError(`"${name}.${hookType}.${methods.join(' ')}"'s function is not a function!`));
+  if (typeof args[1] !== 'function') {
+    throw new TypeError(`"${name}.${hookType}.${methods.join(' ')}"'s function is not a function!`);
+  }
   const func: EmptyVoidFn = args[1];
 
   for (const method of methods) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { IIndexArray, IndexOptions } from './types';
  */
 export function index<T = {}>(fields: T, options?: IndexOptions<T>) {
   return (target: any) => {
-    const indices: IIndexArray<any>[] = Reflect.getMetadata(DecoratorKeys.Index, target) || [];
+    const indices: IIndexArray<any>[] = Reflect.getMetadata(DecoratorKeys.Index, target) ?? [];
     indices.push({ fields, options });
     Reflect.defineMetadata(DecoratorKeys.Index, indices, target);
   };

--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -1,3 +1,4 @@
+import * as assert from 'assert';
 import * as mongoose from 'mongoose';
 
 import { logger } from '../logSettings';
@@ -22,12 +23,10 @@ export function _buildSchema<T, U extends AnyParamConstructor<T>>(
   sch?: mongoose.Schema,
   opt?: mongoose.SchemaOptions
 ) {
-  if (typeof cl !== 'function') {
-    throw new NoValidClass(cl);
-  }
+  assert(typeof cl === 'function', new NoValidClass(cl));
 
   // Options sanity check
-  opt = mergeSchemaOptions(isNullOrUndefined(opt) || typeof opt !== 'object' ? {} : opt, cl);
+  opt = mergeSchemaOptions((isNullOrUndefined(opt) || typeof opt !== 'object') ? {} : opt, cl);
 
   const name = getName(cl);
 
@@ -35,8 +34,8 @@ export function _buildSchema<T, U extends AnyParamConstructor<T>>(
 
   /** Simplify the usage */
   const Schema = mongoose.Schema;
-  const { schemaOptions: ropt }: IModelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, cl) || {};
-  const schemaOptions = Object.assign(ropt || {}, opt);
+  const ropt: IModelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, cl) ?? {};
+  const schemaOptions = Object.assign(ropt?.schemaOptions ?? {}, opt);
 
   const decorators = Reflect.getMetadata(DecoratorKeys.PropCache, cl.prototype) as DecoratedPropertyMetadataMap;
 
@@ -46,7 +45,7 @@ export function _buildSchema<T, U extends AnyParamConstructor<T>>(
     }
   }
 
-  if (!schemas.get(name)) {
+  if (!schemas.has(name)) {
     schemas.set(name, {});
   }
 
@@ -61,14 +60,12 @@ export function _buildSchema<T, U extends AnyParamConstructor<T>>(
 
   const hook = hooks.get(name);
   if (!isNullOrUndefined(hook)) {
-    hook.pre.forEach((obj) => {
-      sch.pre(obj.method, obj.func as EmptyVoidFn);
-    });
+    hook.pre.forEach((obj) => sch.pre(obj.method, obj.func as EmptyVoidFn));
 
     hook.post.forEach((obj) => sch.post(obj.method, obj.func));
   }
 
-  if (plugins.get(name)) {
+  if (plugins.has(name)) {
     for (const plugin of plugins.get(name)) {
       logger.debug('Applying Plugin:', plugin);
       sch.plugin(plugin.mongoosePlugin, plugin.options);
@@ -85,8 +82,8 @@ export function _buildSchema<T, U extends AnyParamConstructor<T>>(
   }
 
   /** Get Metadata for indices */
-  const indices: IIndexArray<any>[] = Reflect.getMetadata(DecoratorKeys.Index, cl) || [];
-  if (!isNullOrUndefined(indices) && Array.isArray(indices)) {
+  const indices: IIndexArray<any>[] = Reflect.getMetadata(DecoratorKeys.Index, cl);
+  if (Array.isArray(indices)) {
     for (const index of indices) {
       logger.debug('Applying Index:', index);
       sch.index(index.fields, index.options);

--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -1,4 +1,3 @@
-import * as assert from 'assert';
 import * as mongoose from 'mongoose';
 
 import { logger } from '../logSettings';
@@ -23,7 +22,9 @@ export function _buildSchema<T, U extends AnyParamConstructor<T>>(
   sch?: mongoose.Schema,
   opt?: mongoose.SchemaOptions
 ) {
-  assert(typeof cl === 'function', new NoValidClass(cl));
+  if (typeof cl !== 'function') {
+    throw new NoValidClass(cl);
+  }
 
   // Options sanity check
   opt = mergeSchemaOptions((isNullOrUndefined(opt) || typeof opt !== 'object') ? {} : opt, cl);

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -1,7 +1,8 @@
-import * as mongoose from 'mongoose';
-
+import * as assert from 'assert';
 import { cloneDeepWith, mergeWith } from 'lodash';
+import * as mongoose from 'mongoose';
 import { format } from 'util';
+
 import { logger } from '../logSettings';
 import {
   AnyParamConstructor,
@@ -9,7 +10,8 @@ import {
   PropOptionsWithNumberValidate,
   PropOptionsWithStringValidate,
   Severity,
-  VirtualOptions
+  VirtualOptions,
+  WhatIsIt
 } from '../types';
 import { DecoratorKeys } from './constants';
 import { constructors, schemas } from './data';
@@ -39,7 +41,7 @@ export function isPrimitive(Type: any): boolean {
  * @returns true, if it is an Object
  */
 export function isObject(Type: any): boolean {
-  if (typeof Type.name === 'string') {
+  if (typeof Type?.name === 'string') {
     let prototype = Type.prototype;
     let name = Type.name;
     while (name) {
@@ -47,7 +49,7 @@ export function isObject(Type: any): boolean {
         return true;
       }
       prototype = Object.getPrototypeOf(prototype);
-      name = prototype ? prototype.constructor.name : null;
+      name = prototype?.constructor.name;
     }
   }
 
@@ -60,7 +62,7 @@ export function isObject(Type: any): boolean {
  * @returns true, if it is an Number
  */
 export function isNumber(Type: any): Type is number {
-  return Type.name === 'Number';
+  return Type?.name === 'Number';
 }
 
 /**
@@ -69,31 +71,31 @@ export function isNumber(Type: any): Type is number {
  * @returns true, if it is an String
  */
 export function isString(Type: any): Type is string {
-  return Type.name === 'String';
+  return Type?.name === 'String';
 }
 
 /**
- * Initialize as Object
- * @param name The Name of the Schema
- * @param key The Property key to set
+ * Initialize the property in the schemas Map
+ * @param name Name of the current Model/Class
+ * @param key Key of the property
+ * @param whatis What should it be for a type?
  */
-export function initAsObject(name: string, key: string): void {
-  if (!schemas.get(name)) {
+export function initProperty(name: string, key: string, whatis: WhatIsIt) {
+  if (!schemas.has(name)) {
     schemas.set(name, {});
   }
-  schemas.get(name)[key] = {};
-}
 
-/**
- * Initialize as Array
- * @param name The Name of the Schema
- * @param key The Property key to set
- */
-export function initAsArray(name: string, key: string): void {
-  if (!schemas.get(name)) {
-    schemas.set(name, {});
+  switch (whatis) {
+    case WhatIsIt.ARRAY:
+      schemas.get(name)[key] = [{}];
+      break;
+    case WhatIsIt.MAP:
+    case WhatIsIt.NONE:
+      schemas.get(name)[key] = {};
+      break;
+    default:
+      throw new TypeError('"whatis" is not supplied OR dosnt have a case yet!');
   }
-  schemas.get(name)[key] = [{}];
 }
 
 /**
@@ -114,10 +116,10 @@ export function isWithStringValidate(
   options: PropOptionsWithStringValidate
 ): options is PropOptionsWithStringValidate {
   return !isNullOrUndefined(
-    options.match
-    || options.enum
-    || options.minlength
-    || options.maxlength
+    options?.match
+    ?? options?.enum
+    ?? options?.minlength
+    ?? options?.maxlength
   );
 }
 
@@ -128,7 +130,7 @@ export function isWithStringValidate(
 export function isWithStringTransform(
   options: PropOptionsWithStringValidate
 ): options is PropOptionsWithStringValidate {
-  return !isNullOrUndefined(options.lowercase || options.uppercase || options.trim);
+  return !isNullOrUndefined(options.lowercase ?? options.uppercase ?? options.trim);
 }
 
 /**
@@ -136,7 +138,7 @@ export function isWithStringTransform(
  * @param options The raw Options
  */
 export function isWithNumberValidate(options: PropOptionsWithNumberValidate): options is PropOptionsWithNumberValidate {
-  return !isNullOrUndefined(options.min || options.max);
+  return !isNullOrUndefined(options.min ?? options.max);
 }
 
 const virtualOptions = ['localField', 'foreignField'];
@@ -188,15 +190,11 @@ export function assignMetadata(key: DecoratorKeys, value: unknown, cl: new () =>
  * @internal
  */
 export function mergeMetadata<T = any>(key: DecoratorKeys, value: unknown, cl: new () => {}): T {
-  if (typeof key !== 'string') {
-    throw new TypeError(`"${key}"(key) is not a string! (assignMetadata)`);
-  }
-  if (typeof cl !== 'function') {
-    throw new NoValidClass(cl);
-  }
+  assert(typeof key === 'string', new TypeError(`"${key}"(key) is not a string! (assignMetadata)`));
+  assert(typeof cl === 'function', new NoValidClass(cl));
 
   // Please dont remove the other values from the function, even when unused - it is made to be clear what is what
-  const current = cloneDeepWith(Reflect.getMetadata(key, cl) || {}, (val, ckey, obj, stack) => customMerger(key, val));
+  const current = cloneDeepWith(Reflect.getMetadata(key, cl) ?? {}, (val, ckey, obj, stack) => customMerger(key, val));
 
   return mergeWith({}, current, value,
     (objValue, srcValue, ckey, object, source, stack) => customMerger(key, srcValue));
@@ -233,20 +231,17 @@ export function mergeSchemaOptions<T, U extends AnyParamConstructor<T>>(value: m
  * @param cl The Class
  */
 export function getName<T, U extends AnyParamConstructor<T>>(cl: U) {
-  const options: IModelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, cl) || {};
+  const options: IModelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, cl) ?? {};
   const baseName = cl.name;
 
   if (options.options && options.options.automaticName) {
-    const suffix = (options.options ? options.options.customName : undefined) ||
-      (options.schemaOptions ? options.schemaOptions.collection : undefined);
+    const suffix = options?.options?.customName ?? options?.schemaOptions?.collection;
 
-    return suffix ? `${baseName}_${suffix}` : baseName;
+    return !isNullOrUndefined(suffix) ? `${baseName}_${suffix}` : baseName;
   }
 
-  if (options.options && typeof options.options.customName === 'string') {
-    if (options.options.customName.length <= 0) {
-      throw new TypeError(`"customName" must be a string AND at least one character ("${cl.name}")`);
-    }
+  if (typeof options?.options?.customName === 'string') {
+    assert(options.options.customName.length > 0, new TypeError(`"customName" must be a string AND at least one character ("${cl.name}")`));
 
     return options.options.customName;
   }
@@ -259,11 +254,17 @@ export function getName<T, U extends AnyParamConstructor<T>>(cl: U) {
  * @param cl The Type
  */
 export function isNotDefined(cl: any) {
-  return typeof cl === 'function' &&
-    !isPrimitive(cl) &&
-    cl !== Object &&
-    cl !== mongoose.Schema.Types.Buffer &&
-    isNullOrUndefined(schemas.get(getName(cl)));
+  try { // this could be simplified to one return, but this is made to make it more readable
+    assert(typeof cl === 'function');
+    assert(!isPrimitive(cl));
+    assert(cl !== Object);
+    assert(cl !== mongoose.Schema.Types.Buffer);
+    assert(!schemas.has(getName(cl)));
+
+    return true;
+  } catch (err) {
+    return false;
+  }
 }
 
 /**
@@ -304,9 +305,9 @@ export function mapArrayOptions(
     if (Type === mongoose.Schema.Types.Mixed) {
       warnMixed(target, pkey);
     }
-  } else if (isNullOrUndefined(Type.prototype.OptionsConstructor)) {
-    throw new TypeError('Type does not have an valid "OptionsConstructor"!');
   }
+
+  assert(!isNullOrUndefined(Type.prototype.OptionsConstructor), new TypeError('Type does not have an valid "OptionsConstructor"!'));
 
   const options = Object.assign({}, rawOptions); // for sanity
 
@@ -331,12 +332,12 @@ export function mapArrayOptions(
     logger.info('The Type "%s" does not have an OptionsConstructor', getName(Type));
   }
 
-  if (typeof options.innerOptions === 'object') {
+  if (typeof options?.innerOptions === 'object') {
     for (const [key, value] of Object.entries(options.innerOptions)) {
       returnObject.type[0][key] = value;
     }
   }
-  if (typeof options.outerOptions === 'object') {
+  if (typeof options?.outerOptions === 'object') {
     for (const [key, value] of Object.entries(options.outerOptions)) {
       returnObject[key] = value;
     }
@@ -355,23 +356,21 @@ export function mapArrayOptions(
  */
 export function warnMixed(target: any, key: string | symbol): void | never {
   const name = getName(target);
-  const modelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, target) || {};
+  const modelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, target) ?? {};
 
-  if (modelOptions.options) {
-    switch (modelOptions.options.allowMixed) {
-      default:
-      case Severity.WARN:
-        logger.warn('Implicitly setting "Mixed" is not allowed! (%s, %s)', name, key);
+  switch (modelOptions?.options?.allowMixed) {
+    default:
+    case Severity.WARN:
+      logger.warn('Implicitly setting "Mixed" is not allowed! (%s, %s)', name, key);
 
-        return;
-      case Severity.ALLOW:
-        return;
-      case Severity.ERROR:
-        throw new TypeError(format('Implicitly setting "Mixed" is not allowed! (%s, %s)', name, key));
-    }
+      break;
+    case Severity.ALLOW:
+      break;
+    case Severity.ERROR:
+      throw new TypeError(format('Implicitly setting "Mixed" is not allowed! (%s, %s)', name, key));
   }
 
-  return; // always return, if "allowMixed" is not set
+  return; // always return, if "allowMixed" is not "ERROR"
 }
 
 /**

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,5 @@
 import { plugins } from './internal/data';
+import { getName } from './internal/utils';
 import { Func } from './types';
 
 /**
@@ -8,12 +9,12 @@ import { Func } from './types';
  */
 export function plugin(mongoosePlugin: Func, options?: any) {
   return (target: any) => {
-    const name: string = target.name;
+    const name: string = getName(target);
 
     options = typeof options !== 'object' ? {} : options; // ensure it is an object, even if empty
 
     /* istanbul ignore else */
-    if (!plugins.get(name)) {
+    if (!plugins.has(name)) {
       plugins.set(name, []);
     }
     plugins.get(name).push({ mongoosePlugin, options });

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -1,5 +1,4 @@
 /* imports */
-import * as assert from 'assert';
 import * as mongoose from 'mongoose';
 import 'reflect-metadata';
 import * as semver from 'semver';
@@ -85,7 +84,9 @@ export abstract class Typegoose {
  * ```
  */
 export function getModelForClass<T, U extends AnyParamConstructor<T>>(cl: U, options?: IModelOptions) {
-  assert(typeof cl === 'function', new NoValidClass(cl));
+  if (typeof cl !== 'function') {
+    throw new NoValidClass(cl);
+  }
   options = typeof options === 'object' ? options : {};
 
   const roptions: IModelOptions = mergeMetadata(DecoratorKeys.ModelOptions, options, cl);
@@ -129,7 +130,9 @@ export function setModelForClass<T, U extends AnyParamConstructor<T>>(cl: U) {
  * @returns Returns the Build Schema
  */
 export function buildSchema<T, U extends AnyParamConstructor<T>>(cl: U, options?: mongoose.SchemaOptions) {
-  assert(typeof cl === 'function', new NoValidClass(cl));
+  if (typeof cl !== 'function') {
+    throw new NoValidClass(cl);
+  }
 
   const mergedOptions = mergeSchemaOptions(options, cl);
 
@@ -170,8 +173,12 @@ export function buildSchema<T, U extends AnyParamConstructor<T>>(cl: U, options?
  * ```
  */
 export function addModelToTypegoose<T, U extends AnyParamConstructor<T>>(model: mongoose.Model<any>, cl: U) {
-  assert(model.prototype instanceof mongoose.Model, new TypeError(`"${model}" is not a valid Model!`));
-  assert(typeof cl === 'function', new NoValidClass(cl));
+  if (!(model.prototype instanceof mongoose.Model)) {
+    throw new TypeError(`"${model}" is not a valid Model!`);
+  }
+  if (typeof cl !== 'function') {
+    throw new NoValidClass(cl);
+  }
 
   const name = getName(cl);
 
@@ -194,8 +201,12 @@ export function addModelToTypegoose<T, U extends AnyParamConstructor<T>>(model: 
  * @param key
  */
 export function deleteModel(name: string) {
-  assert(typeof name === 'string', new TypeError('name is not an string! (deleteModel)'));
-  assert(models.has(name), new Error(`Model "${name}" could not be found`));
+  if (typeof name !== 'string') {
+    throw new TypeError('name is not an string! (deleteModel)');
+  }
+  if (!models.has(name)) {
+    throw new Error(`Model "${name}" could not be found`);
+  }
 
   logger.debug('Deleting Model "%s"', name);
 
@@ -209,7 +220,9 @@ export function deleteModel(name: string) {
  * @param cl The Class
  */
 export function deleteModelWithClass<T, U extends AnyParamConstructor<T>>(cl: U) {
-  assert(typeof cl === 'function', new NoValidClass(cl));
+  if (typeof cl !== 'function') {
+    throw new NoValidClass(cl);
+  }
 
   return deleteModel(getName(cl));
 }
@@ -233,8 +246,12 @@ export function getDiscriminatorModelForClass<T, U extends AnyParamConstructor<T
   cl: U,
   id?: string
 ) {
-  assert(from.prototype instanceof mongoose.Model, new TypeError(`"${from}" is not a valid Model!`));
-  assert(typeof cl === 'function', new NoValidClass(cl));
+  if (!(from.prototype instanceof mongoose.Model)) {
+    throw new TypeError(`"${from}" is not a valid Model!`);
+  }
+  if (typeof cl !== 'function') {
+    throw new NoValidClass(cl);
+  }
 
   const name = getName(cl);
   if (models.has(name)) {

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -10,6 +10,10 @@ if (semver.lt(mongoose.version, '5.7.7')) {
   throw new Error('Please use mongoose 5.7.7 or higher');
 }
 
+if (semver.lt(process.version.slice(1), '8.10.0')) {
+  logger.warn('You are using a NodeJS Version below 8.10.0, Please Upgrade!');
+}
+
 import * as defaultClasses from './defaultClasses';
 import { DecoratorKeys } from './internal/constants';
 import { constructors, models } from './internal/data';

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -15,7 +15,7 @@ import { DecoratorKeys } from './internal/constants';
 import { constructors, models } from './internal/data';
 import { NoValidClass } from './internal/errors';
 import { _buildSchema } from './internal/schema';
-import { getName, isNullOrUndefined, mergeMetadata, mergeSchemaOptions } from './internal/utils';
+import { getName, mergeMetadata, mergeSchemaOptions } from './internal/utils';
 import { logger } from './logSettings';
 import {
   AnyParamConstructor,
@@ -81,31 +81,25 @@ export abstract class Typegoose {
  * ```
  */
 export function getModelForClass<T, U extends AnyParamConstructor<T>>(cl: U, options?: IModelOptions) {
-  assert(typeof cl !== 'function', new Error());
-  if (typeof cl !== 'function') {
-    throw new NoValidClass(cl);
-  }
+  assert(typeof cl === 'function', new NoValidClass(cl));
   options = typeof options === 'object' ? options : {};
 
   const roptions: IModelOptions = mergeMetadata(DecoratorKeys.ModelOptions, options, cl);
   const name = getName(cl);
 
-  if (models.get(name)) {
+  if (models.has(name)) {
     return models.get(name) as ReturnModelType<U, T>;
   }
 
-  let model = mongoose.model.bind(mongoose);
-  if (!isNullOrUndefined(roptions.existingConnection)) {
-    model = roptions.existingConnection.model.bind(roptions.existingConnection);
-  } else if (!isNullOrUndefined(roptions.existingMongoose)) {
-    model = roptions.existingMongoose.model.bind(roptions.existingMongoose);
-  }
+  const model = roptions?.existingConnection?.model.bind(roptions.existingConnection)
+    ?? roptions?.existingMongoose?.model.bind(roptions.existingMongoose)
+    ?? mongoose.model.bind(mongoose);
 
   const compiledmodel: mongoose.Model<any> = model(name, buildSchema(cl, roptions.schemaOptions));
-  const refetchedOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, cl) as IModelOptions || {};
+  const refetchedOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, cl) as IModelOptions ?? {};
 
-  if (refetchedOptions && refetchedOptions.options && refetchedOptions.options.runSyncIndexes) {
-    compiledmodel.syncIndexes({}); // the "{}" is because @types/mongoose dosnt allow it without ...
+  if (refetchedOptions?.options?.runSyncIndexes) {
+    compiledmodel.syncIndexes();
   }
 
   return addModelToTypegoose(compiledmodel, cl);
@@ -131,9 +125,7 @@ export function setModelForClass<T, U extends AnyParamConstructor<T>>(cl: U) {
  * @returns Returns the Build Schema
  */
 export function buildSchema<T, U extends AnyParamConstructor<T>>(cl: U, options?: mongoose.SchemaOptions) {
-  if (typeof cl !== 'function') {
-    throw new NoValidClass(cl);
-  }
+  assert(typeof cl === 'function', new NoValidClass(cl));
 
   const mergedOptions = mergeSchemaOptions(options, cl);
 
@@ -141,7 +133,7 @@ export function buildSchema<T, U extends AnyParamConstructor<T>>(cl: U, options?
   /** Parent Constructor */
   let parentCtor = Object.getPrototypeOf(cl.prototype).constructor;
   // iterate trough all parents
-  while (parentCtor && parentCtor.name !== 'Object') {
+  while (parentCtor?.name !== 'Object') {
     /* istanbul ignore next */
     if (parentCtor.name === 'Typegoose') { // TODO: remove this "if", if the Typegoose class gets removed [DEPRECATION]
       deprecate(() => undefined, 'The Typegoose Class is deprecated, please try to remove it')();
@@ -174,18 +166,14 @@ export function buildSchema<T, U extends AnyParamConstructor<T>>(cl: U, options?
  * ```
  */
 export function addModelToTypegoose<T, U extends AnyParamConstructor<T>>(model: mongoose.Model<any>, cl: U) {
-  if (!(model.prototype instanceof mongoose.Model)) {
-    throw new TypeError(`"${model}" is not a valid Model!`);
-  }
-  if (typeof cl !== 'function') {
-    throw new NoValidClass(cl);
-  }
+  assert(model.prototype instanceof mongoose.Model, new TypeError(`"${model}" is not a valid Model!`));
+  assert(typeof cl === 'function', new NoValidClass(cl));
 
   const name = getName(cl);
 
-  if (constructors.get(name)) {
+  if (constructors.has(name)) {
     throw new Error(format('It seems like "addModelToTypegoose" got called twice\n'
-      + 'Or multiple classes with the same name are used, which currently isnt supported!'
+      + 'Or multiple classes with the same name are used, which is not supported!'
       + '(%s)', name));
   }
 
@@ -202,15 +190,10 @@ export function addModelToTypegoose<T, U extends AnyParamConstructor<T>>(model: 
  * @param key
  */
 export function deleteModel(name: string) {
-  if (typeof name !== 'string') {
-    throw new TypeError('name is not an string! (deleteModel)');
-  }
+  assert(typeof name === 'string', new TypeError('name is not an string! (deleteModel)'));
+  assert(models.has(name), new Error(`Model "${name}" could not be found`));
 
   logger.debug('Deleting Model "%s"', name);
-
-  if (!models.has(name)) {
-    throw new Error(`Model "${name}" could not be found`);
-  }
 
   mongoose.connection.deleteModel(name);
   models.delete(name);
@@ -222,9 +205,7 @@ export function deleteModel(name: string) {
  * @param cl The Class
  */
 export function deleteModelWithClass<T, U extends AnyParamConstructor<T>>(cl: U) {
-  if (typeof cl !== 'function') {
-    throw new NoValidClass(cl);
-  }
+  assert(typeof cl === 'function', new NoValidClass(cl));
 
   return deleteModel(getName(cl));
 }
@@ -248,8 +229,11 @@ export function getDiscriminatorModelForClass<T, U extends AnyParamConstructor<T
   cl: U,
   id?: string
 ) {
+  assert(from.prototype instanceof mongoose.Model, new TypeError(`"${from}" is not a valid Model!`));
+  assert(typeof cl === 'function', new NoValidClass(cl));
+
   const name = getName(cl);
-  if (models.get(name)) {
+  if (models.has(name)) {
     return models.get(name) as ReturnModelType<U, T>;
   }
   const sch = buildSchema(cl) as mongoose.Schema & { paths: object };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import * as mongoose from 'mongoose';
+
 import { Base } from './defaultClasses';
 
 /**

--- a/test/models/persistentModel.ts
+++ b/test/models/persistentModel.ts
@@ -20,7 +20,7 @@ export abstract class PersistentModel {
 
   // define an instanceMethod that is called by the derived class
   public async addCar(this: DocumentType<PersistentModel>, car: Car) {
-    if (!this.cars) {
+    if (!Array.isArray(this.cars)) {
       this.cars = [];
     }
 

--- a/test/models/user.ts
+++ b/test/models/user.ts
@@ -75,7 +75,7 @@ export class User extends defaultClasses.FindOrCreate {
   }
 
   public async incrementAge(this: DocumentType<User>) {
-    const age = this.age || 1;
+    const age = this?.age ?? 1;
     this.age = age + 1;
 
     return this.save();

--- a/test/tests/dClasses.test.ts
+++ b/test/tests/dClasses.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+
 import { TestTimeStamps, TestTimeStampsModel } from '../models/dClasses';
 
 /**

--- a/test/tests/errors.test.ts
+++ b/test/tests/errors.test.ts
@@ -1,7 +1,7 @@
-import { assert, expect } from 'chai';
-
 import { AssertionError } from 'assert';
+import { assert, expect } from 'chai';
 import { model, Schema } from 'mongoose';
+
 import { pre } from '../../src/hooks';
 import { DecoratorKeys } from '../../src/internal/constants';
 import {
@@ -20,6 +20,7 @@ import {
   buildSchema,
   deleteModel,
   deleteModelWithClass,
+  getDiscriminatorModelForClass,
   getModelForClass,
   modelOptions,
   setGlobalOptions
@@ -171,7 +172,7 @@ export function suite() {
       try {
         // @ts-ignore
         addModelToTypegoose(model('hello', new Schema()), 'not class');
-        assert.fail('Expected to throw "TypeError"');
+        assert.fail('Expected to throw "NoValidClass"');
       } catch (err) {
         expect(err).to.be.an.instanceOf(NoValidClass);
       }
@@ -201,6 +202,36 @@ export function suite() {
       try {
         // @ts-ignore
         getModelForClass('hello');
+        assert.fail('Expected to throw "NoValidClass"');
+      } catch (err) {
+        expect(err).to.be.an.instanceOf(NoValidClass);
+      }
+    });
+
+    it('should error if no valid class is supplied to "deleteModelWithClass" [NoValidClass]', () => {
+      try {
+        // @ts-ignore
+        deleteModelWithClass(true);
+        assert.fail('Expected to throw "NoValidClass"');
+      } catch (err) {
+        expect(err).to.be.an.instanceOf(NoValidClass);
+      }
+    });
+
+    it('should error if no valid class is supplied to "mergeSchemaOptions" [NoValidClass]', () => {
+      try {
+        // @ts-ignore
+        mergeSchemaOptions({}, true);
+        assert.fail('Expected to throw "NoValidClass"');
+      } catch (err) {
+        expect(err).to.be.an.instanceOf(NoValidClass);
+      }
+    });
+
+    it('should error if no valid class is supplied to "getDiscriminatorModelForClass" [NoValidClass]', () => {
+      try {
+        // @ts-ignore
+        getDiscriminatorModelForClass(model('NoValidClassgetDiscriminatorModelForClass', {}), true);
         assert.fail('Expected to throw "NoValidClass"');
       } catch (err) {
         expect(err).to.be.an.instanceOf(NoValidClass);
@@ -262,16 +293,6 @@ export function suite() {
     });
   });
 
-  it('should error if no valid class is supplied to "mergeSchemaOptions" [NoValidClass]', () => {
-    try {
-      // @ts-ignore
-      mergeSchemaOptions({}, true);
-      assert.fail('Expected to throw "NoValidClass"');
-    } catch (err) {
-      expect(err).to.be.an.instanceOf(NoValidClass);
-    }
-  });
-
   it('should throw an error if a self-contained class is used', () => {
     try {
       class TestSelfContained {
@@ -292,16 +313,6 @@ export function suite() {
       assert.fail('Expected to throw "TypeError"');
     } catch (err) {
       expect(err).to.be.an.instanceOf(TypeError);
-    }
-  });
-
-  it('should throw when "deleteModelWithClass" is called and its not a valid class [NoValidClass]', () => {
-    try {
-      // @ts-ignore
-      deleteModelWithClass(true);
-      assert.fail('Expected to throw "NoValidClass"');
-    } catch (err) {
-      expect(err).to.be.an.instanceOf(NoValidClass);
     }
   });
 
@@ -425,6 +436,16 @@ export function suite() {
 
       getModelForClass(HeterogeneousClass);
 
+      assert.fail('Expected to throw "TypeError"');
+    } catch (err) {
+      expect(err).to.be.an.instanceOf(TypeError);
+    }
+  });
+
+  it('should error if no valid model is supplied to "getDiscriminatorModelForClass" [TypeError]', () => {
+    try {
+      // @ts-ignore
+      getDiscriminatorModelForClass(true);
       assert.fail('Expected to throw "TypeError"');
     } catch (err) {
       expect(err).to.be.an.instanceOf(TypeError);

--- a/test/tests/errors.test.ts
+++ b/test/tests/errors.test.ts
@@ -80,7 +80,7 @@ export function suite() {
         public test: undefined;
       }
       getModelForClass(TestNME);
-      assert.fail('Expected to throw "InvalidPropError"');
+      assert.fail('Expected to throw "NoMetadataError"');
     } catch (err) {
       expect(err).to.be.an.instanceOf(NoMetadataError);
     }

--- a/test/tests/getClassForDocument.test.ts
+++ b/test/tests/getClassForDocument.test.ts
@@ -1,7 +1,7 @@
+import { fail } from 'assert';
 import { expect } from 'chai';
 import * as mongoose from 'mongoose';
 
-import { fail } from 'assert';
 import { getClassForDocument } from '../../src/internal/utils';
 import { Genders } from '../enums/genders';
 import { Car as CarType, model as Car } from '../models/car';

--- a/test/tests/globalOptions.test.ts
+++ b/test/tests/globalOptions.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+
 import { globalOptions } from '../../src/internal/data';
 import { setGlobalOptions } from '../../src/typegoose';
 import { Severity } from '../../src/types';

--- a/test/tests/inheritance.test.ts
+++ b/test/tests/inheritance.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+
 import { model as inheritanceClass, Skyscraper } from '../models/inheritanceClass';
 
 /**
@@ -26,6 +27,7 @@ export function suite() {
       }
     } as Skyscraper;
     const instance = await inheritanceClass.create(input);
+
     expect(instance.mainGarage.slotsForCars).to.equals(3);
     expect(instance.mainGarage.width).to.equals(100);
     // this has an any type assertion, because it shouldnt exists on this type, what is tested here
@@ -39,6 +41,7 @@ export function suite() {
       }]
     } as Skyscraper;
     const instance = await inheritanceClass.create(input);
+
     expect(instance.garagesInArea).to.be.lengthOf(1);
     const firstGarage = instance.garagesInArea.pop();
     expect(firstGarage.slotsForCars).to.equals(2);

--- a/test/tests/overwrittenModel.test.ts
+++ b/test/tests/overwrittenModel.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+
 import { deleteModel, deleteModelWithClass, getModelForClass } from '../../src/typegoose';
 import { NormalUser, OverwrittenUser } from './../models/overwrittenUser';
 

--- a/test/tests/shouldAdd.test.ts
+++ b/test/tests/shouldAdd.test.ts
@@ -120,35 +120,33 @@ export function suite() {
   });
 
   it('Should support dynamic references via refPath', async () => {
-    const sprite = new Beverage({
+    const sprite = await Beverage.create({
       isDecaf: true,
       isSugarFree: false
     });
-    await sprite.save();
 
-    await new Beverage({
+    await Beverage.create({
       isDecaf: false,
       isSugarFree: true
-    }).save();
+    });
 
-    const vespa = new Scooter({
+    const vespa = await Scooter.create({
       makeAndModel: 'Vespa'
     });
-    await vespa.save();
 
-    await new Inventory({
+    await Inventory.create({
       refItemPathName: 'Beverage',
       kind: sprite,
       count: 10,
       value: 1.99
-    }).save();
+    });
 
-    await new Inventory({
+    await Inventory.create({
       refItemPathName: 'Scooter',
       kind: vespa,
       count: 1,
       value: 1099.98
-    }).save();
+    });
 
     // I should now have two "inventory" items, with different embedded reference documents.
     const items = await Inventory.find({}).populate('kind').exec();

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -143,9 +143,10 @@ export function suite() {
     const optionEnum: [string, unknown] = (autoNumberPath as any).options.enum;
     expect(optionEnum).to.be.deep.equal(['Hi', 'Hi2']);
 
-    const doc = new model({ autonumber: AutoNumberEnum.Hi2 } as AutoNumberClass);
-    expect(doc).to.not.be.equal(undefined);
-    expect(doc.autonumber).to.be.equal('Hi2');
+    // TODO: re-enable this
+    // const doc = new model({ autonumber: AutoNumberEnum.Hi2 } as AutoNumberClass);
+    // expect(doc).to.not.be.equal(undefined);
+    // expect(doc.autonumber).to.be.equal('Hi2');
   });
 
   it('should work with Objects in Class [szokodiakos#54]', async () => {

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -142,6 +142,10 @@ export function suite() {
 
     const optionEnum: [string, unknown] = (autoNumberPath as any).options.enum;
     expect(optionEnum).to.be.deep.equal(['Hi', 'Hi2']);
+
+    const doc = new model({ autonumber: AutoNumberEnum.Hi2 } as AutoNumberClass);
+    expect(doc).to.not.be.equal(undefined);
+    expect(doc.autonumber).to.be.equal('Hi2');
   });
 
   it('should work with Objects in Class [szokodiakos#54]', async () => {

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -1,5 +1,6 @@
 import { assert, expect } from 'chai';
 import * as mongoose from 'mongoose';
+
 import { DecoratorKeys } from '../../src/internal/constants';
 import { assignMetadata, mergeMetadata, mergeSchemaOptions } from '../../src/internal/utils';
 import {
@@ -63,7 +64,6 @@ export function suite() {
   });
 
   it('should make use of addModelToTypegoose', async () => {
-    // addModelToTypegoose
     class TestAMTT {
       @prop({ required: true })
       public somevalue!: string;
@@ -74,6 +74,7 @@ export function suite() {
     schema.add({ somesecondvalue: { type: String, required: true } });
     const model = addModelToTypegoose(mongoose.model(TestAMTT.name, schema), TestAMTT);
     const doc = await model.create({ somevalue: 'hello from SV', somesecondvalue: 'hello from SSV' } as TestAMTT);
+
     expect(doc).to.not.be.an('undefined');
     expect(doc.somevalue).to.equal('hello from SV');
     expect(doc.somesecondvalue).to.equal('hello from SSV');
@@ -153,6 +154,7 @@ export function suite() {
 
     const model = getModelForClass(TESTObject);
     const doc = await model.create({ test: { anotherTest: 'hello' } } as TESTObject);
+
     expect(doc).to.not.be.an('undefined');
     expect(doc.test).to.be.an('object');
     expect(doc.test.anotherTest).to.be.equal('hello');

--- a/test/utils/config.ts
+++ b/test/utils/config.ts
@@ -23,7 +23,7 @@ enum EConfig {
 
 const env: NodeJS.ProcessEnv = process.env; // just to write less
 
-let path: string = env.CONFIG ? env.CONFIG : './test/config.json';
+let path: string = env.CONFIG ?? './test/config.json';
 path = fs.existsSync(path) ? path : './test/config_default.json';
 
 const configRAW: Readonly<IConfig> =
@@ -31,16 +31,16 @@ const configRAW: Readonly<IConfig> =
 
 // ENV || CONFIG-FILE || DEFAULT
 const configFINAL: Readonly<IConfig> = {
-  Memory: (env.C_USE_IN_MEMORY === 'true' ? true : undefined) ||
+  Memory: env.C_USE_IN_MEMORY !== undefined ||
     (typeof configRAW.Memory === 'boolean' ? configRAW.Memory : true),
-  DataBase: env.C_DATABASE || configRAW.DataBase || 'typegooseTest',
+  DataBase: env.C_DATABASE ?? configRAW?.DataBase ?? 'typegooseTest',
   Port: parseInt(env.C_PORT as string, 10) || configRAW.Port || 27017,
   Auth: {
-    User: env.C_AUTH_USER || configRAW.Auth.User || '',
-    Passwd: env.C_AUTH_PASSWD || configRAW.Auth.Passwd || '',
-    DB: env.C_AUTH_DB || configRAW.Auth.DB || ''
+    User: env.C_AUTH_USER ?? configRAW?.Auth?.User ?? '',
+    Passwd: env.C_AUTH_PASSWD || configRAW?.Auth?.Passwd || '',
+    DB: env.C_AUTH_DB || configRAW?.Auth?.DB || ''
   },
-  IP: env.C_IP || configRAW.IP || 'mongodb'
+  IP: env.C_IP ?? configRAW.IP ?? 'localhost'
 };
 
 /** Small callback for the tests below */

--- a/test/utils/mongooseConnect.ts
+++ b/test/utils/mongooseConnect.ts
@@ -33,7 +33,7 @@ export async function connect(): Promise<void> {
       dbName: config.DataBase,
       autoIndex: true
     } as mongoose.ConnectionOptions;
-    if (config.Auth.User.length > 0) {
+    if (config?.Auth?.User?.length > 0) {
       Object.assign(options, {
         user: config.Auth.User,
         pass: config.Auth.Passwd,


### PR DESCRIPTION
## Why is this an PR that is not merged?

well... typescript 3.7 is not released yet

## Is there an ETA?

Typescript aims to release 3.7 at 5.11.2019 (d/m/y)

## What does this PR currently do?

- refactor to use the new "Optional Chaining"
- refactor to use the new "Nullish Coalescing"
- enhances many checks to be more explicit

## What does this PR still need to do?

- check if some checks can be replaced with "Assertion Functions"
- update to latest code base when 3.7 comes out

---

closes typegoose#56