### PR TITLE
Fix schema building when there is a `name` getter on a model class

### DIFF
--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -238,7 +238,10 @@ export function getName<T, U extends AnyParamConstructor<T>>(cl: U) {
     Reflect.getMetadata(DecoratorKeys.ModelOptions, cl) ??
     Reflect.getMetadata(DecoratorKeys.ModelOptions, cl.constructor) ??
     {};
-  const baseName = cl.name ?? cl.constructor.name;
+
+  const baseName = (isNullOrUndefined(cl.name) || isGetter(cl, 'name'))
+    ? cl.constructor.name
+    : cl.name;
 
   if (options.options?.automaticName) {
     const suffix = options.options?.customName ?? options.schemaOptions?.collection;
@@ -383,6 +386,12 @@ export function warnMixed(target: any, key: string | symbol): void | never {
  */
 export function isNullOrUndefined(val: unknown): val is null | undefined {
   return val === null || val === undefined;
+}
+
+export function isGetter(object: any, key: PropertyKey) {
+  const desc = Object.getOwnPropertyDescriptor(object, key);
+
+  return desc && (typeof desc.get === 'function') && (typeof desc.set === 'undefined');
 }
 
 /**

--- a/test/tests/shouldAdd.test.ts
+++ b/test/tests/shouldAdd.test.ts
@@ -296,4 +296,21 @@ export function suite() {
       expect(doc.some).to.equal('hello2');
     }
   });
+
+  it('should add schema paths when there is a virtual called `name`', () => {
+    class T {
+      @prop()
+      public something: string;
+
+      public get name() {
+        return '';
+      }
+    }
+
+    const schema = buildSchema(T);
+    const someprop = schema.path('something');
+    expect(schema).to.not.be.an('undefined');
+    expect(someprop).to.not.be.an('undefined');
+  });
+
 }


### PR DESCRIPTION
- Adds test for building schema on a class with `name` getter
- Exclude getters when getting a decorator target's name

<!--
## Make sure you have done these steps

- Make sure you have Read & followed these steps in [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

## Misc

- [ ] Is this a prototype? <!--Is this PR already finished or not yet ready?-->
- [x] Written Tests for it? <!--Written Tests for this feature / fix? (only if needed)-->
- [x] Already read & followed [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)?

(didn't sign the commit, hope that's OK)

## Related Issues

<!--add "fixes" / "closes" before an number to indicate that these will be fixed by this pr-->

- Fixes #136 
