### PR TITLE
Fix guides link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ To ask questions or just talk with us [join our Discord Server](https://discord.
 ## Documentation
 
 [Here is the Documentation](https://typegoose.github.io/typegoose/docs)  
-[Here are Guides](https://typegoose.github.io/typegoose/guides)  
+[Here are the Guides](https://typegoose.github.io/typegoose/guides/quick-start-guide/)  
 
 ## Migrate to 6.0.0
 


### PR DESCRIPTION
Modify README to link to the correct guides page

The link previously linked to https://typegoose.github.io/typegoose/guides (doesn't exist). I've changed it to link https://typegoose.github.io/typegoose/guides/quick-start-guide/ (has the same effect as going to homepage and clicking "Guides").

## Collection of what it does / fixes

- changes a link to point to the correct url to make sure the user goes to the guides page

## Misc

This PR is finished.
- [ ] Written Tests for it? <!--Written Tests for this feature / fix? (only if needed)--> No need.
- [X] Already read & followed [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)
