### PR TITLE
docs: virtual props and select prop option

### DIFF
--- a/github-page/_docs/decorators/prop.md
+++ b/github-page/_docs/decorators/prop.md
@@ -10,7 +10,7 @@ title: "Prop"
 
 Accepts Type: `boolean`
 
-Set if this Property is required (best practice is `public property!: any`, note the `!`)
+Set if this Property is required (best practice is `public property!: any`, note the `!`)  
 For more infomation look at [Mongoose's Documentation](http://mongoosejs.com/docs/api.html#schematype_SchemaType-required)
 
 Example:
@@ -198,7 +198,8 @@ class Dummy {
 
 Accepts Type: `boolean`
 
-Set it to `false` if you want to retrieve data without this property
+Set it to `false` if you want to retrieve data without this property by default  
+-> [Read more in mongoose's offical documentation](https://mongoosejs.com/docs/api.html#schematype_SchemaType-select)
 
 ```ts
 class Dummy {
@@ -208,10 +209,14 @@ class Dummy {
 ```
 
 In order to retrieve a prop marked as `select: false`, you must explicit ask for it:
+
 ```ts
-const dummies = await DummyModel.find().select('+hello') // all dummies have hello property
+// find all in the collection and have the "hello" property selected
+const dummies = await DummyModel.find().select('+hello').exec();
 ```
-Remember: `select` function accepts an array as well
+
+Note: `select()` accepts an array as well
+Note: `select()` accepts an long string with space as an seperator
 
 ### get & set
 

--- a/github-page/_docs/decorators/prop.md
+++ b/github-page/_docs/decorators/prop.md
@@ -10,7 +10,7 @@ title: "Prop"
 
 Accepts Type: `boolean`
 
-Set if this Property is required (best practice is `public property!: any`, note the `!`)  
+Set if this Property is required (best practice is `public property!: any`, note the `!`)
 For more infomation look at [Mongoose's Documentation](http://mongoosejs.com/docs/api.html#schematype_SchemaType-required)
 
 Example:
@@ -194,6 +194,25 @@ class Dummy {
 }
 ```
 
+### select
+
+Accepts Type: `boolean`
+
+Set it to `false` if you want to retrieve data without this property
+
+```ts
+class Dummy {
+   @prop({ select: false })
+   public hello: string;
+}
+```
+
+In order to retrieve a prop marked as `select: false`, you must explicit ask for it:
+```ts
+const dummies = await DummyModel.find().select('+hello') // all dummies have hello property
+```
+Remember: `select` function accepts an array as well
+
 ### get & set
 
 Accepts Type: `(input) => output`
@@ -214,8 +233,8 @@ class Dummy {
 
 Accepts Type: `any`
 
-This option is mainly used for [get & set](#get--set) to override the inferred type  
-but it can also be used to override the inferred type of any prop  
+This option is mainly used for [get & set](#get--set) to override the inferred type
+but it can also be used to override the inferred type of any prop
 
 -> this overwriting is meant as a last resort, please open a new issue if you need to use it
 

--- a/github-page/_docs/virtuals.md
+++ b/github-page/_docs/virtuals.md
@@ -46,8 +46,8 @@ Resulting Document in MongoDB:
 
 *This shows the difference between [`@prop`'s get & set]({{ site.baseurl }}{% link _docs/decorators/prop.md %}#get--set) and [this one]({{ site.baseurl }}{% link _docs/virtuals.md %}#get--set)*
 
-The difference between `@prop`'s and this one is simple, `@prop`'s get & set are ***actual properties*** that get saved to the database, only with a conversion layer  
-The get & set of *getter's & setter's* are absolutly virtual  
+The difference between `@prop`'s and this one is simple, `@prop`'s get & set are ***actual properties*** that get saved to the database, only with a conversion layer
+The get & set of *getter's & setter's* are absolutly virtual
 
 ## Virtual Populate
 
@@ -97,3 +97,27 @@ class Parent {
   public one: Ref<Sub>;
 }
 ```
+
+Note: by default Mongoose doesn't retrieve virtuals props in JSON, in order to achieve that add these `schemaOptions` on class.
+
+Example:
+
+```ts
+@modelOptions({
+  schemaOptions: {
+    toJSON: {virtuals: true},
+    toObject: {virtuals: true},
+  },
+})
+class Parent {
+  @prop({
+    ref: "Sub",
+    foreignField: 'parent',
+    localField: '_id',
+    justOne: true // please know that when this is not included, mongoose will return an array
+  })
+  public one: Ref<Sub>;
+}
+```
+
+If you want this behavior for more classes, the inhenritance is available.

--- a/github-page/_docs/virtuals.md
+++ b/github-page/_docs/virtuals.md
@@ -46,8 +46,8 @@ Resulting Document in MongoDB:
 
 *This shows the difference between [`@prop`'s get & set]({{ site.baseurl }}{% link _docs/decorators/prop.md %}#get--set) and [this one]({{ site.baseurl }}{% link _docs/virtuals.md %}#get--set)*
 
-The difference between `@prop`'s and this one is simple, `@prop`'s get & set are ***actual properties*** that get saved to the database, only with a conversion layer
-The get & set of *getter's & setter's* are absolutly virtual
+The difference between `@prop`'s and this one is simple, `@prop`'s get & set are ***actual properties*** that get saved to the database, only with a conversion layer  
+The get & set of *getter's & setter's* are absolutly virtual  
 
 ## Virtual Populate
 
@@ -98,15 +98,21 @@ class Parent {
 }
 ```
 
-Note: by default Mongoose doesn't retrieve virtuals props in JSON, in order to achieve that add these `schemaOptions` on class.
+## Extra Notes
+
+### Why is my virtual not included in the output?
+
+By default mongoose dosnt output virtuals, to archive this you need to add `toObject` and(/or) `toObject` to `schemaOptions` in `@modelOptions`
+
+Note: it can be set in `@modelOptions`, but it can be set in `getModelForClass` too (and in the `doc.toJSON()`/`doc.toObject()` functions)
 
 Example:
 
 ```ts
 @modelOptions({
   schemaOptions: {
-    toJSON: {virtuals: true},
-    toObject: {virtuals: true},
+    toJSON: { virtuals: true },
+    toObject: { virtuals: true },
   },
 })
 class Parent {
@@ -120,4 +126,4 @@ class Parent {
 }
 ```
 
-If you want this behavior for more classes, the inhenritance is available.
+Note: these options will be applied to all classes that inherit the class that got the options applied


### PR DESCRIPTION
Adding documentation for:
- settings to return virtual props on json
- select prop options

Implements #167 #174

<!--
Try to use a template, found at .github/PULL_REQUEST_TEMPLATE/
[here](https://github.com/typegoose/typegoose/tree/master/.github/PULL_REQUEST_TEMPLATE)
please dont forget to click on raw, and copy that, not the already "compiled" one
-->

<!--
## Make sure you have done these steps

- Make sure you have Read & followed these steps in [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

## Misc

- [ ] Is this a prototype? <!--Is this PR already finished or not yet ready?-->
- [ ] Written Tests for it? <!--Written Tests for this feature / fix? (only if needed)-->
- [x] Already read & followed [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)?

## Related Issues

<!--add "fixes" / "closes" before an number to indicate that these will be fixed by this pr-->

- closes #167
- closes #174
