### PR TITLE
Add mongoose types to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ class User {
 ## Install
 
 `npm i -s @typegoose/typegoose`
+`npm i --save-dev @types/mongoose`
 
 You also need to install `mongoose`, since version 5 it is listed as a peer-dependency
 


### PR DESCRIPTION
To fix this: https://github.com/typegoose/typegoose/issues/176

<!--
Try to use a template, found at .github/PULL_REQUEST_TEMPLATE/
[here](https://github.com/typegoose/typegoose/tree/master/.github/PULL_REQUEST_TEMPLATE)
please dont forget to click on raw, and copy that, not the already "compiled" one
-->

<!--
## Make sure you have done these steps

- Make sure you have Read & followed these steps in [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

## Misc

- [ ] Is this a prototype? <!--Is this PR already finished or not yet ready?-->
- [ ] Written Tests for it? <!--Written Tests for this feature / fix? (only if needed)-->
- [ ] Already read & followed [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)?

## Related Issues

<!--add "fixes" / "closes" before an number to indicate that these will be fixed by this pr-->

- #1
