### PR TITLE
Fix plugins generic type

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,7 +7,7 @@ import { Func } from './types';
  * @param mongoosePlugin The Plugin to plug-in
  * @param options Options for the Plugin, if any
  */
-export function plugin<T extends any[] | any>(mongoosePlugin: Func, options?: T) {
+export function plugin<T = any>(mongoosePlugin: Func, options?: T) {
   // dont check if options is an object, because any plugin could make it anything
   return (target: any) => {
     const name: string = getName(target);


### PR DESCRIPTION
With `T extends any | any[]` I can't type options with a interface

<!--
Try to use a template, found at .github/PULL_REQUEST_TEMPLATE/
[here](https://github.com/typegoose/typegoose/tree/master/.github/PULL_REQUEST_TEMPLATE)
please dont forget to click on raw, and copy that, not the already "compiled" one
-->

<!--
## Make sure you have done these steps

- Make sure you have Read & followed these steps in [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

## Misc

- [ ] Is this a prototype? <!--Is this PR already finished or not yet ready?-->
- [ ] Written Tests for it? <!--Written Tests for this feature / fix? (only if needed)-->
- [ ] Already read & followed [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)?