### PR TITLE
Remove type inference document's properties on model.

### DIFF
--- a/github-page/_guides/advanced/plugins.md
+++ b/github-page/_guides/advanced/plugins.md
@@ -64,48 +64,6 @@ const SomeClassModel = getModelForClass(SomeClass);
 })();
 ```
 
-## @typegoose/auto-increment
-
-The Typegoose project provides an [`auto-increment` plugin](https://github.com/typegoose/auto-increment) for mongoose, here is how to use it:
-
-### AutoIncrementSimple
-
-Always increments the field on each save
-
-```ts
-@plugin<AutoIncrementSimplePluginOptions>(AutoIncrementSimple, [{ field: "someIncrementedField" }])
-class SomeClass {
-  @prop() // does not need to be empty
-  public someIncrementedField: number;
-}
-
-const SomeModel = getModelForClass(SomeClass);
-
-const doc = await SomeModel.create({ someIncrementedField: 10 });
-
-await doc.save(); // someIncrementedField will be 11
-```
-
-### AutoIncrementID
-
-Only increases the field if the document is *new* and the counter is stored in an counter-collection
-(default field: `_id`)
-
-```ts
-@plugin<AutoIncrementOptionsID>(AutoIncrementID, {})
-class SomeClass {
-  @prop()
-  public _id: number;
-
-  @prop() // does not need to be empty
-  public someIncrementedField: number;
-}
-
-const SomeModel = getModelForClass(SomeClass);
-
-const doc = await SomeModel.create({ someIncrementedField: 10 }); // _id will be 1
-```
-
 ---
 
 Please note that some or all of the listed plugins might not have an `@types` package, so you mostly have to declare it as a model

--- a/github-page/_guides/advanced/plugins.md
+++ b/github-page/_guides/advanced/plugins.md
@@ -64,6 +64,48 @@ const SomeClassModel = getModelForClass(SomeClass);
 })();
 ```
 
+## @typegoose/auto-increment
+
+The Typegoose project provides an [`auto-increment` plugin](https://github.com/typegoose/auto-increment) for mongoose, here is how to use it:
+
+### AutoIncrementSimple
+
+Always increments the field on each save
+
+```ts
+@plugin<AutoIncrementSimplePluginOptions>(AutoIncrementSimple, [{ field: "someIncrementedField" }])
+class SomeClass {
+  @prop() // does not need to be empty
+  public someIncrementedField: number;
+}
+
+const SomeModel = getModelForClass(SomeClass);
+
+const doc = await SomeModel.create({ someIncrementedField: 10 });
+
+await doc.save(); // someIncrementedField will be 11
+```
+
+### AutoIncrementID
+
+Only increases the field if the document is *new* and the counter is stored in an counter-collection
+(default field: `_id`)
+
+```ts
+@plugin<AutoIncrementOptionsID>(AutoIncrementID, {})
+class SomeClass {
+  @prop()
+  public _id: number;
+
+  @prop() // does not need to be empty
+  public someIncrementedField: number;
+}
+
+const SomeModel = getModelForClass(SomeClass);
+
+const doc = await SomeModel.create({ someIncrementedField: 10 }); // _id will be 1
+```
+
 ---
 
 Please note that some or all of the listed plugins might not have an `@types` package, so you mostly have to declare it as a model

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export type DocumentType<T> = (T extends Base ? Omit<mongoose.Document, '_id'> &
  * Used Internally for ModelTypes
  * @internal
  */
-export type ModelType<T> = mongoose.Model<DocumentType<T>> & T;
+export type ModelType<T> = mongoose.Model<DocumentType<T>>;
 /**
  * Any-param Constructor
  * @internal

--- a/test/tests/shouldAdd.test.ts
+++ b/test/tests/shouldAdd.test.ts
@@ -6,7 +6,7 @@ import { Alias, model as AliasModel } from '../models/alias';
 import { GetClassTestParent, GetClassTestParentModel, GetClassTestSub } from '../models/getClass';
 import { GetSet, GetSetModel } from '../models/getSet';
 import { InternetUserModel } from '../models/internetUser';
-import { BeverageModel as Beverage, InventoryModel as Inventory, ScooterModel as Scooter } from '../models/inventory';
+import { BeverageModel as Beverage, InventoryModel as Inventory, ScooterModel as Scooter, Beverage as BeverageClass } from '../models/inventory';
 import { OptionsClass, OptionsModel } from '../models/options';
 import { UserModel } from '../models/user';
 import {
@@ -150,10 +150,10 @@ it('Should support dynamic references via refPath', async () => {
 
   // I should now have two "inventory" items, with different embedded reference documents.
   const items = await Inventory.find({}).populate('kind').exec();
-  expect((items[0].kind as typeof Beverage).isDecaf).toEqual(true);
+  expect((items[0].kind as BeverageClass).isDecaf).toEqual(true);
 
   // wrong type to make TypeScript happy
-  expect((items[1].kind as typeof Beverage).isDecaf).toEqual(undefined);
+  expect((items[1].kind as BeverageClass).isDecaf).toEqual(undefined);
 });
 
 it('it should alias correctly', () => {


### PR DESCRIPTION
<!--
Try to use a template, found at .github/PULL_REQUEST_TEMPLATE/
[here](https://github.com/typegoose/typegoose/tree/master/.github/PULL_REQUEST_TEMPLATE)
please don't forget to click on raw, and copy that, not the already "compiled" one
-->
A small fix to remove type inference document's properties on model.

```ts
UserModel.firstName // Got Property 'firstName' does not exist on type 'ReturnModelType<typeof User, unknown>'
```
<!--
## Make sure you have done these steps

- Make sure you have Read & followed these steps in [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

## Misc

- [ ] Is this a prototype? <!--Is this PR already finished or not yet ready?-->
- [x] Written Tests for it? (Fix type in existing test)
- [x] Already read & followed [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)?

## Related Issues

<!--add "fixes" / "closes" before an number to indicate that these will be fixed by this pr-->

- #220 
