### PR TITLE
Overridden property accessors for inherited classes & schema build order

### DIFF
--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -71,7 +71,7 @@ export function _buildSchema<T, U extends AnyParamConstructor<T>>(
   sch.loadClass(cl);
 
   // Override getters & setters.
-  const accessors = Object.getOwnPropertyDescriptors(cl.prototype)
+  const accessors = Object.getOwnPropertyDescriptors(cl.prototype);
   for (const key in accessors) {
     if (key.match(/^(constructor)$/) || !(sch as any).virtuals[key]) {
       continue;

--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -70,6 +70,22 @@ export function _buildSchema<T, U extends AnyParamConstructor<T>>(
 
   sch.loadClass(cl);
 
+  // Override getters & setters.
+  const accessors = Object.getOwnPropertyDescriptors(cl.prototype)
+  for (const key in accessors) {
+    if (key.match(/^(constructor)$/) || !(sch as any).virtuals[key]) {
+      continue;
+    }
+
+    if (typeof accessors[key].get === 'function') {
+      (sch as any).virtuals[key].getters = [accessors[key].get];
+    }
+
+    if (typeof accessors[key].set === 'function') {
+      (sch as any).virtuals[key].setters = [accessors[key].set];
+    }
+  }
+
   if (isFinalSchema) {
     // Hooks
     {

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -107,13 +107,25 @@ export function buildSchema<T, U extends AnyParamConstructor<T>>(cl: U, options?
   let sch: mongoose.Schema<U>;
   /** Parent Constructor */
   let parentCtor = Object.getPrototypeOf(cl.prototype).constructor;
+  const parentClasses: AnyParamConstructor<T>[] = [];
+
   // iterate trough all parents
   while (parentCtor?.name !== 'Object') {
-    // extend schema
-    sch = _buildSchema(parentCtor, sch, mergedOptions, false);
+    // add parent class to the beginning of the array if not added yet.
+    if (!parentClasses.find(cls => cls.name === parentCtor.name)) {
+      parentClasses.unshift(parentCtor);
+    }
+
     // set next parent
     parentCtor = Object.getPrototypeOf(parentCtor.prototype).constructor;
   }
+
+  // iterate and build parent class schemas
+  for (const parentClass of parentClasses) {
+    // extend schema
+    sch = _buildSchema(parentClass, sch, mergedOptions, false);
+  }
+
   // get schema of current model
   sch = _buildSchema(cl, sch, mergedOptions);
 

--- a/test/models/inheritanceClass.ts
+++ b/test/models/inheritanceClass.ts
@@ -9,6 +9,14 @@ import { arrayProp, getModelForClass, modelOptions, prop } from '../../src/typeg
 export class Building {
   @prop({ default: 100 })
   public width: number;
+
+  public get calculatedWidth() {
+    return this.width;
+  }
+
+  public get assignedGardenArea() {
+    return 300;
+  }
 }
 
 export class OfficeBuilding extends Building {
@@ -35,6 +43,10 @@ export class Skyscraper extends OfficeBuilding {
 
   @arrayProp({ items: Garage, _id: false })
   public garagesInArea: Garage[];
+
+  public get calculatedWidth() {
+    return this.width * this.doors;
+  }
 }
 
 export const SkyscraperModel = getModelForClass(Skyscraper);

--- a/test/tests/inheritance.test.ts
+++ b/test/tests/inheritance.test.ts
@@ -48,3 +48,10 @@ it('should set all parent props for nested array items', async () => {
   // sanity check
   expect(firstGarage).not.toHaveProperty('_id');
 });
+
+it('should override inherited property accessor', () => {
+  const instance = new SkyscraperModel();
+
+  expect(instance.calculatedWidth).toEqual(400);
+  expect(instance.assignedGardenArea).toEqual(300);
+});


### PR DESCRIPTION
The example used throughout the PR description;
```ts
class Building {
  ...

  public get value() {
    return 1;
  }

  ...
}

class OfficeBuilding extends Building { ... }

class Skyscraper extends OfficeBuilding {
  ...

  public get value() {
    return 100;
  }

  ...
}

const SkyscraperModel = getModelForClass(Skyscraper);
```

--

This PR fixes two things;

1.  Build order for inherited schemas.

Previously, when building parent schemas in `while` loop, they were being built from bottom to top. This was resulting in building the `OfficeBuilding` class first, then the `Building` class. However, the logical order is, first the `Building` class, then the `OfficeBuilding` class. This is needed for the fix below.

2.  Overridden inherited property accessors.

Fixes overriden virtuals not being overriden in schemas. As for the example, the `Skyscraper` class' `value` property returns `1`, while it should return `100`.

## Misc

- [ ] Is this a prototype? <!--Is this PR already finished or not yet ready?-->
- [x] Written Tests for it? <!--Written Tests for this feature / fix? (only if needed)-->
- [x] Already read & followed [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)?