### PR TITLE
Types for query methods

### DIFF
--- a/github-page/_docs/decorators/queryMethod.md
+++ b/github-page/_docs/decorators/queryMethod.md
@@ -6,15 +6,24 @@ redirect_from:
   - /docs/decorators/queryMethods
 ---
 
-`@queryMethod(func: (...args: any[]) => any)` is a decorator to add [custom query methods](https://thecodebarbarian.com/mongoose-custom-query-methods)
-  - func: the function that should be added
+`@queryMethod(func: (this: ReturnModelType<U, QueryHelpers>, ...args: any[]) => mongoose.DocumentQuery)` is a decorator to add [custom query methods](https://thecodebarbarian.com/mongoose-custom-query-methods)
+- `this` needs to be defined to have the correct types inside the class (and to make it comaptible with `@queryMethod`)
+- `func` is the function that should be added
+- the return type of the function needs to be `mongoose.DocumentQuery`
 
-Note: the function needs to have an name and cant be an array-function (it needs to handle and use `this`)
+Notes:
+- The function needs to have an name and cant be an array-function (it needs to handle and use `this`)
+- It is recommened to to not define the functions inside the decorator, like in the example below
 
 Example:
 
 ```ts
-function findByName(this: ReturnModelType<typeof QueryMethods>, name: string) {
+interface QueryHelpers {
+  findByName: QueryMethod<typeof findByName>;
+  findByLastname: QueryMethod<typeof findByLastname>;
+}
+
+function findByName(this: ReturnModelType<typeof QueryMethods, QueryHelpers>, name: string) {
   return this.find({ name }); // important to not do an "await" and ".exec"
 }
 @queryMethod(findByName)
@@ -24,7 +33,8 @@ class QueryMethods {
 }
 const QueryMethodsModel = getModelForClass(QueryMethods);
 
-const docs: DocumentType<QueryMethods>[] | null = await (QueryMethodsModel.find() as any).findByName('hello').exec();
+// thanks to "QueryHelpers" the function "findByName" should exist here and return the correct type
+const docs: DocumentType<QueryMethods>[] = await QueryMethodsModel.find().findByName('hello').orFail().exec();
 ```
 
 Important: currently there is no practical way to add the function to the available types, so the query needs to be cast as `any` to allow the function to be used, what gets returned needs to be casted aswell

--- a/github-page/_docs/types/returnModelType.md
+++ b/github-page/_docs/types/returnModelType.md
@@ -4,13 +4,13 @@ redirect_from:
   - /docs/types/returnmodeltype
 ---
 
-The Type `ReturnModelType<T>` is the type used to have type information for a class converted to an mongoose Model
+The Type `ReturnModelType<T, QueryHelpers>` is the type used to have type information for a class converted to an mongoose Model
+- `T` is the logical `AND` of `mongoose.Model<DocumentType<T>>` and `T`
+- `QueryHelpers` is for an Query-Helpers interface, [more here]({{ site.baseurl }}{% link _docs/decorators/queryMethod.md%})
 
--> It is the logical `AND` of `mongoose.Model<DocumentType<T>>` and `T`
-
-Note: It has to be always with `typeof Class`, otherwise it will not work
-
-Note: This type should always be used over (the now internal) `ModelType`
+Notes:
+- It has to be always with `typeof Class`, otherwise it will not work
+- This type should always be used over (the now internal) `ModelType`
 
 ## Example
 

--- a/github-page/changelog.md
+++ b/github-page/changelog.md
@@ -33,6 +33,12 @@ redirect_from:
 - Set proper function type for `queryMethod`
 - Added the ability to define option `ref` with an arrow-function [(`ref: () => type`)]({{ site.baseurl }}{% link _guides/advanced/reference-other-classes.md %}#referencing-other-classes)
 - All Decorators are now exported PascalCased & camelCased
+- Actually export the `@queryMethod` decorator
+- The `@queryMethod` decorator now has correct types [{% include gitissue repo="typegoose" num=247 %}]
+- The functions `addModelToTypegoose`, `getModelForClass`, `buildSchema`, `deleteModelWithClass`, `getDiscriminatorModelForClass` now have the `T` generic removed (it was unnecessary)
+- The functions `addModelToTypegoose`, `getModelForClass`, `getDiscriminatorModelForClass` now have an new optional generic `QueryHelpers`
+- The Type `ReturnModelType` now has the `T` generic removed (it was unnecessary)
+- The Type `ReturnModelType` now has an second optional generic `QueryHelpers`
 - [IC] add some tslint rules & apply them
 - [IC] enable "strictNullChecks" & fix accordingly
 

--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -27,7 +27,7 @@ import { assertionIsClass, assignGlobalModelOptions, getName, isNullOrUndefined,
  * @returns Returns the Build Schema
  * @private
  */
-export function _buildSchema<T, U extends AnyParamConstructor<T>>(
+export function _buildSchema<U extends AnyParamConstructor<any>>(
   cl: U,
   sch?: mongoose.Schema,
   opt?: mongoose.SchemaOptions,

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -279,7 +279,7 @@ function customMerger(key: string | number, val: unknown): any {
  * @param value The value to use
  * @param cl The Class to get the values from
  */
-export function mergeSchemaOptions<T, U extends AnyParamConstructor<T>>(value: mongoose.SchemaOptions | undefined, cl: U) {
+export function mergeSchemaOptions<U extends AnyParamConstructor<any>>(value: mongoose.SchemaOptions | undefined, cl: U) {
   return mergeMetadata<IModelOptions>(DecoratorKeys.ModelOptions, { schemaOptions: value }, cl).schemaOptions;
 }
 
@@ -297,7 +297,7 @@ export function getRightTarget(target: any): any {
  * (with suffix)
  * @param cl The Class
  */
-export function getName<T, U extends AnyParamConstructor<T>>(cl: U) {
+export function getName<U extends AnyParamConstructor<any>>(cl: U) {
   const ctor: any = getRightTarget(cl);
   const options: IModelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, ctor) ?? {};
   const baseName: string = ctor.name;

--- a/src/queryMethod.ts
+++ b/src/queryMethod.ts
@@ -21,8 +21,8 @@ import type { AnyParamConstructor, QueryMethodMap, ReturnModelType } from './typ
  * }
  * ```
  */
-export function queryMethod<T extends AnyParamConstructor<any>>(
-  func: (this: ReturnModelType<T>, ...params: any[]) => mongoose.DocumentQuery<any, any>
+export function queryMethod<QueryHelpers, T, U extends AnyParamConstructor<T>>(
+  func: (this: ReturnModelType<U, T, QueryHelpers>, ...params: any[]) => mongoose.DocumentQuery<any, any>
 ) {
   return (target: any) => {
     logger.info('Adding query method "%s" to %s', func.name, getName(target));

--- a/src/queryMethod.ts
+++ b/src/queryMethod.ts
@@ -10,7 +10,11 @@ import type { AnyParamConstructor, QueryMethodMap, ReturnModelType } from './typ
  * @param func Query function
  * @example
  * ```ts
- * function findByTitle(this: ReturnModelType<typeof Event>, title: string) {
+ * interface FindHelpers {
+ *   findByTitle: QueryMethod<typeof findByTitle>;
+ * }
+ *
+ * function findByTitle(this: ReturnModelType<typeof Event, FindHelpers>, title: string) {
  *  return this.find({ title });
  * }
  *
@@ -19,10 +23,12 @@ import type { AnyParamConstructor, QueryMethodMap, ReturnModelType } from './typ
  *  @prop()
  *  public title: string;
  * }
+ *
+ * const EventModel = getModelForClass<typeof Event, FindHelpers>(Event);
  * ```
  */
-export function queryMethod<QueryHelpers, T, U extends AnyParamConstructor<T>>(
-  func: (this: ReturnModelType<U, T, QueryHelpers>, ...params: any[]) => mongoose.DocumentQuery<any, any>
+export function queryMethod<QueryHelpers, U extends AnyParamConstructor<any>>(
+  func: (this: ReturnModelType<U, QueryHelpers>, ...params: any[]) => mongoose.DocumentQuery<any, any>
 ) {
   return (target: any) => {
     logger.info('Adding query method "%s" to %s', func.name, getName(target));

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -59,7 +59,7 @@ parseENV(); // call this before anything to ensure they are applied
  * const NameModel = getModelForClass(Name);
  * ```
  */
-export function getModelForClass<T, U extends AnyParamConstructor<T>>(cl: U, options?: IModelOptions) {
+export function getModelForClass<T, U extends AnyParamConstructor<T>, QueryHelpers>(cl: U, options?: IModelOptions) {
   assertionIsClass(cl);
   options = typeof options === 'object' ? options : {};
 
@@ -67,7 +67,7 @@ export function getModelForClass<T, U extends AnyParamConstructor<T>>(cl: U, opt
   const name = getName(cl);
 
   if (models.has(name)) {
-    return models.get(name) as ReturnModelType<U, T>;
+    return models.get(name) as ReturnModelType<U, T, QueryHelpers>;
   }
 
   const model = roptions?.existingConnection?.model.bind(roptions.existingConnection)
@@ -81,7 +81,7 @@ export function getModelForClass<T, U extends AnyParamConstructor<T>>(cl: U, opt
     compiledmodel.syncIndexes();
   }
 
-  return addModelToTypegoose(compiledmodel, cl);
+  return addModelToTypegoose<T, U, QueryHelpers>(compiledmodel, cl);
 }
 
 /**
@@ -146,7 +146,7 @@ export function buildSchema<T, U extends AnyParamConstructor<T>>(cl: U, options?
  * const model = addModelToTypegoose(mongoose.model("Name", schema), Name);
  * ```
  */
-export function addModelToTypegoose<T, U extends AnyParamConstructor<T>>(model: mongoose.Model<any>, cl: U) {
+export function addModelToTypegoose<T, U extends AnyParamConstructor<T>, QueryHelpers = {}>(model: mongoose.Model<any>, cl: U) {
   assertion(model.prototype instanceof mongoose.Model, new TypeError(`"${model}" is not a valid Model!`));
   assertionIsClass(cl);
 
@@ -163,7 +163,7 @@ export function addModelToTypegoose<T, U extends AnyParamConstructor<T>>(model: 
   models.set(name, model);
   constructors.set(name, cl);
 
-  return models.get(name) as ReturnModelType<U, T>;
+  return models.get(name) as ReturnModelType<U, T, QueryHelpers>;
 }
 
 /**

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -30,6 +30,7 @@ export * from './hooks';
 export * from './plugin';
 export * from './index';
 export * from './modelOptions';
+export * from './queryMethod';
 export * from './typeguards';
 export * as defaultClasses from './defaultClasses';
 export * as errors from './internal/errors';
@@ -53,7 +54,7 @@ parseENV(); // call this before anything to ensure they are applied
  * const NameModel = getModelForClass(Name);
  * ```
  */
-export function getModelForClass<T, U extends AnyParamConstructor<T>, QueryHelpers>(cl: U, options?: IModelOptions) {
+export function getModelForClass<U extends AnyParamConstructor<any>, QueryHelpers = {}>(cl: U, options?: IModelOptions) {
   assertionIsClass(cl);
   options = typeof options === 'object' ? options : {};
 
@@ -61,7 +62,7 @@ export function getModelForClass<T, U extends AnyParamConstructor<T>, QueryHelpe
   const name = getName(cl);
 
   if (models.has(name)) {
-    return models.get(name) as ReturnModelType<U, T, QueryHelpers>;
+    return models.get(name) as ReturnModelType<U, QueryHelpers>;
   }
 
   const model =
@@ -76,7 +77,7 @@ export function getModelForClass<T, U extends AnyParamConstructor<T>, QueryHelpe
     compiledmodel.syncIndexes();
   }
 
-  return addModelToTypegoose<T, U, QueryHelpers>(compiledmodel, cl);
+  return addModelToTypegoose<U, QueryHelpers>(compiledmodel, cl);
 }
 
 /**
@@ -106,7 +107,7 @@ export function getModelWithString<U extends AnyParamConstructor<any>>(key: stri
  * const NameModel = mongoose.model("Name", NameSchema);
  * ```
  */
-export function buildSchema<T, U extends AnyParamConstructor<T>>(cl: U, options?: mongoose.SchemaOptions) {
+export function buildSchema<U extends AnyParamConstructor<any>>(cl: U, options?: mongoose.SchemaOptions) {
   assertionIsClass(cl);
 
   const mergedOptions = mergeSchemaOptions(options, cl);
@@ -141,7 +142,7 @@ export function buildSchema<T, U extends AnyParamConstructor<T>>(cl: U, options?
  * const model = addModelToTypegoose(mongoose.model("Name", schema), Name);
  * ```
  */
-export function addModelToTypegoose<T, U extends AnyParamConstructor<T>, QueryHelpers = {}>(model: mongoose.Model<any>, cl: U) {
+export function addModelToTypegoose<U extends AnyParamConstructor<any>, QueryHelpers = {}>(model: mongoose.Model<any>, cl: U) {
   assertion(model.prototype instanceof mongoose.Model, new TypeError(`"${model}" is not a valid Model!`));
   assertionIsClass(cl);
 
@@ -166,7 +167,7 @@ export function addModelToTypegoose<T, U extends AnyParamConstructor<T>, QueryHe
   models.set(name, model);
   constructors.set(name, cl);
 
-  return models.get(name) as ReturnModelType<U, T, QueryHelpers>;
+  return models.get(name) as ReturnModelType<U, QueryHelpers>;
 }
 
 /**
@@ -204,7 +205,7 @@ export function deleteModel(name: string) {
  * deleteModelWithClass(Name);
  * ```
  */
-export function deleteModelWithClass<T, U extends AnyParamConstructor<T>>(cl: U) {
+export function deleteModelWithClass<U extends AnyParamConstructor<any>>(cl: U) {
   assertionIsClass(cl);
 
   return deleteModel(getName(cl));
@@ -224,13 +225,17 @@ export function deleteModelWithClass<T, U extends AnyParamConstructor<T>>(cl: U)
  * const C2Model = getDiscriminatorModelForClass(C1Model, C1);
  * ```
  */
-export function getDiscriminatorModelForClass<T, U extends AnyParamConstructor<T>>(from: mongoose.Model<any>, cl: U, id?: string) {
+export function getDiscriminatorModelForClass<U extends AnyParamConstructor<any>, QueryHelpers = {}>(
+  from: mongoose.Model<any>,
+  cl: U,
+  id?: string
+) {
   assertion(from.prototype instanceof mongoose.Model, new TypeError(`"${from}" is not a valid Model!`));
   assertionIsClass(cl);
 
   const name = getName(cl);
   if (models.has(name)) {
-    return models.get(name) as ReturnModelType<U, T>;
+    return models.get(name) as ReturnModelType<U, QueryHelpers>;
   }
   const sch = buildSchema(cl) as mongoose.Schema & { paths: any; };
 
@@ -241,5 +246,5 @@ export function getDiscriminatorModelForClass<T, U extends AnyParamConstructor<T
 
   const model = from.discriminator(name, sch, id ? id : name);
 
-  return addModelToTypegoose(model, cl);
+  return addModelToTypegoose<U, QueryHelpers>(model, cl);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -434,10 +434,8 @@ export interface IPluginsArray<T> {
  */
 export type VirtualPopulateMap = Map<string, any & VirtualOptions>;
 
-/**
- * Return query methods
- */
-export type DocumentQuery<T, U> = mongoose.DocumentQuery<DocumentType<T>[], DocumentType<T>, U>;
+
+export type QueryMethod<T extends (...args: any) => any> = (...args: Parameters<T>) => ReturnType<T>;
 
 /**
  * Used for the Reflection of Query Methods

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export type AnyParamConstructor<T> = new (...args: any) => T;
 /**
  * The Type of a Model that gets returned by "getModelForClass" and "setModelForClass"
  */
-export type ReturnModelType<U extends AnyParamConstructor<T>, T = any, QueryHelpers = {}> = ModelType<InstanceType<U>, QueryHelpers> & U;
+export type ReturnModelType<U extends AnyParamConstructor<any>, QueryHelpers = {}> = ModelType<InstanceType<U>, QueryHelpers> & U;
 
 /** @internal */
 export type Func = (...args: any[]) => any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -434,6 +434,23 @@ export interface IPluginsArray<T> {
 export type VirtualPopulateMap = Map<string, any & VirtualOptions>;
 
 
+/**
+ * Gets the signature (parameters with their types, and the return type) of a function type.
+ * 
+ * @description Should be used when defining an interface for a class that uses query methods.
+ * 
+ * @example
+ * ```ts
+ * function sendMessage(recipient: string, sender: string, priority: number, retryIfFails: boolean) {
+ *  // some logic...
+ *  return true;
+ * }
+ * 
+ * // Both of the following types will be identical.
+ * type SendMessageType = QueryMethod<typeof sendMessage>;
+ * type SendMessageManualType = (recipient: string, sender: string, priority: number, retryIfFails: boolean) => boolean;
+ * ```
+ */
 export type QueryMethod<T extends (...args: any) => any> = (...args: Parameters<T>) => ReturnType<T>;
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -436,16 +436,16 @@ export type VirtualPopulateMap = Map<string, any & VirtualOptions>;
 
 /**
  * Gets the signature (parameters with their types, and the return type) of a function type.
- * 
+ *
  * @description Should be used when defining an interface for a class that uses query methods.
- * 
+ *
  * @example
  * ```ts
  * function sendMessage(recipient: string, sender: string, priority: number, retryIfFails: boolean) {
  *  // some logic...
  *  return true;
  * }
- * 
+ *
  * // Both of the following types will be identical.
  * type SendMessageType = QueryMethod<typeof sendMessage>;
  * type SendMessageManualType = (recipient: string, sender: string, priority: number, retryIfFails: boolean) => boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ export type DocumentType<T> = (T extends Base ? Omit<mongoose.Document, '_id'> &
  * Used Internally for ModelTypes
  * @internal
  */
-export type ModelType<T> = mongoose.Model<DocumentType<T>>;
+export type ModelType<T, QueryHelpers = {}> = mongoose.Model<DocumentType<T>, QueryHelpers>;
 /**
  * Any-param Constructor
  * @internal
@@ -28,7 +28,7 @@ export type AnyParamConstructor<T> = new (...args: any) => T;
 /**
  * The Type of a Model that gets returned by "getModelForClass" and "setModelForClass"
  */
-export type ReturnModelType<U extends AnyParamConstructor<T>, T = any> = ModelType<InstanceType<U>> & U;
+export type ReturnModelType<U extends AnyParamConstructor<T>, T = any, QueryHelpers = {}> = ModelType<InstanceType<U>, QueryHelpers> & U;
 
 /** @internal */
 export type Func = (...args: any[]) => any;
@@ -433,6 +433,11 @@ export interface IPluginsArray<T> {
  * ```
  */
 export type VirtualPopulateMap = Map<string, any & VirtualOptions>;
+
+/**
+ * Return query methods
+ */
+export type DocumentQuery<T, U> = mongoose.DocumentQuery<DocumentType<T>[], DocumentType<T>, U>;
 
 /**
  * Used for the Reflection of Query Methods

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -18,7 +18,7 @@ import {
   modelOptions,
   prop
 } from '../../src/typegoose';
-import type { IModelOptions, DocumentQuery, QueryMethodMap, ReturnModelType } from '../../src/types';
+import type { DocumentQuery, IModelOptions, QueryMethodMap, ReturnModelType } from '../../src/types';
 
 // Note: this file is meant for github issue verification & test adding for these
 // -> and when not an outsourced class(/model) is needed

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -18,7 +18,7 @@ import {
   modelOptions,
   prop
 } from '../../src/typegoose';
-import type { DocumentQuery, IModelOptions, QueryMethodMap, ReturnModelType } from '../../src/types';
+import type { IModelOptions, QueryMethod, QueryMethodMap, ReturnModelType } from '../../src/types';
 
 // Note: this file is meant for github issue verification & test adding for these
 // -> and when not an outsourced class(/model) is needed
@@ -404,13 +404,14 @@ it('should add "null" to the enum (addNullToEnum)', async () => {
 
 it('should add query Methods', async () => {
   interface FindHelpers {
-    findByName(name: string): DocumentQuery<QueryMethods, FindHelpers>;
+    findByName: QueryMethod<typeof findByName>;
+    findByLastname: QueryMethod<typeof findByLastname>;
   }
-  function findByName(this: ReturnModelType<typeof QueryMethods>, name: string) {
+  function findByName(this: ReturnModelType<typeof QueryMethods, QueryMethods, FindHelpers>, name: string) {
     return this.find({ name }); // important to not do an "await" and ".exec"
   }
 
-  function findByLastname(this: ReturnModelType<typeof QueryMethods>, lastname: string) {
+  function findByLastname(this: ReturnModelType<typeof QueryMethods, QueryMethods, FindHelpers>, lastname: string) {
     return this.find({ lastname }); // important to not do an "await" and ".exec"
   }
 
@@ -434,8 +435,7 @@ it('should add query Methods', async () => {
 
   const doc = await QueryMethodsModel.create({ name: 'hello', lastname: 'world' });
 
-  const found: DocumentType<QueryMethods>[] | null =
-    await (QueryMethodsModel.find() as any).findByName('hello').findByLastname('world').exec();
+  const found: DocumentType<QueryMethods>[] | null = await QueryMethodsModel.find().findByName('hello').findByLastname('world').exec();
   assertion(isDocumentArray(found), new Error('Found is not an document array'));
   expect(found[0].toObject()).toEqual(doc.toObject());
 });

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -18,7 +18,7 @@ import {
   modelOptions,
   prop
 } from '../../src/typegoose';
-import type { IModelOptions, QueryMethodMap, ReturnModelType } from '../../src/types';
+import type { IModelOptions, DocumentQuery, QueryMethodMap, ReturnModelType } from '../../src/types';
 
 // Note: this file is meant for github issue verification & test adding for these
 // -> and when not an outsourced class(/model) is needed
@@ -403,6 +403,9 @@ it('should add "null" to the enum (addNullToEnum)', async () => {
 });
 
 it('should add query Methods', async () => {
+  interface FindHelpers {
+    findByName(name: string): DocumentQuery<QueryMethods, FindHelpers>;
+  }
   function findByName(this: ReturnModelType<typeof QueryMethods>, name: string) {
     return this.find({ name }); // important to not do an "await" and ".exec"
   }
@@ -412,10 +415,10 @@ it('should add query Methods', async () => {
     public name: string;
   }
 
-  const QueryMethodsModel = getModelForClass(QueryMethods);
+  const QueryMethodsModel = getModelForClass<QueryMethods, typeof QueryMethods, FindHelpers>(QueryMethods);
   const doc = await QueryMethodsModel.create({ name: 'hello' });
 
-  const found: DocumentType<QueryMethods>[] | null = await (QueryMethodsModel.find() as any).findByName('hello').exec();
+  const found: DocumentType<QueryMethods>[] | null = await QueryMethodsModel.find().findByName('hello').exec();
   assertion(isDocumentArray(found), new Error('Found is not an document array'));
   expect(found[0].toObject()).toEqual(doc.toObject());
 

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -407,11 +407,11 @@ it('should add query Methods', async () => {
     findByLastname: QueryMethod<typeof findByLastname>;
   }
   function findByName(this: ReturnModelType<typeof QueryMethodsClass, FindHelpers>, name: string) {
-    return this.find({ name }); // important to not do an "await" and ".exec"
+    return this.find({ name });
   }
 
   function findByLastname(this: ReturnModelType<typeof QueryMethodsClass, FindHelpers>, lastname: string) {
-    return this.find({ lastname }); // important to not do an "await" and ".exec"
+    return this.find({ lastname });
   }
 
   @queryMethod(findByName)


### PR DESCRIPTION
This is the only thing I could think of for query methods types. Using mongoose's own types for `Model`'s `QueryHelpers`, which is added as the third type argument to the `getModelForClass` function.

- closes #236