### PR TITLE
fix: Ref<> type broken with optional property

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -261,7 +261,7 @@ export type PropOptionsWithNumberValidate = PropOptions & ValidateNumberOptions;
 export type PropOptionsWithStringValidate = PropOptions & TransformStringOptions & ValidateStringOptions;
 export type PropOptionsWithValidate = PropOptionsWithNumberValidate | PropOptionsWithStringValidate | VirtualOptions;
 
-export type RefType = number | string | mongoose.Types.ObjectId | Buffer;
+export type RefType = number | string | mongoose.Types.ObjectId | Buffer | undefined;
 export type RefSchemaType = typeof mongoose.Schema.Types.Number |
   typeof mongoose.Schema.Types.String |
   typeof mongoose.Schema.Types.Buffer |
@@ -271,7 +271,7 @@ export type RefSchemaType = typeof mongoose.Schema.Types.Number |
  * Reference another Model
  */
 // export type Ref<R, T extends RefType = mongoose.Types.ObjectId> = R | T; // old type, kept for easy revert
-export type Ref<R, T extends RefType = R extends { _id: RefType; } ? R['_id'] : mongoose.Types.ObjectId> = R | T;
+export type Ref<R, T extends RefType = R extends { _id?: RefType } ? NonNullable<R['_id']> : mongoose.Types.ObjectId> = R | T;
 
 /**
  * An Function type for a function that doesn't have any arguments and doesn't return anything

--- a/test/models/refTests.ts
+++ b/test/models/refTests.ts
@@ -15,6 +15,16 @@ export class RefTestString {
   public _id!: string;
 }
 
+export class RefTestStringOptional {
+  @prop()
+  public _id?: string;
+}
+
+export class RefTestStringOrUndefined {
+  @prop()
+  public _id!: string | undefined;
+}
+
 export const RefTestBufferModel = getModelForClass(RefTestBuffer);
 export const RefTestNumberModel = getModelForClass(RefTestNumber);
 export const RefTestStringModel = getModelForClass(RefTestString);
@@ -47,6 +57,20 @@ export class RefTest {
 
   @arrayProp({ ref: 'RefTestString', refType: mongoose.Schema.Types.String })
   public refArrayString2?: Ref<RefTestString, string>[];
+
+  // ref string optional or undefined
+  @prop({ ref: RefTestString, refType: mongoose.Schema.Types.String })
+  public refFieldStringOptional?: Ref<RefTestStringOptional /* , string */>; // RefType not set, to know if automatic Ref is brocken
+
+  @prop({ ref: 'RefTestString', refType: mongoose.Schema.Types.String })
+  public refFieldStringOrUndefined?: Ref<RefTestStringOrUndefined /* , string */>; // RefType not set, to know if automatic Ref is brocken
+
+  // ref string array
+  @arrayProp({ ref: RefTestString, refType: mongoose.Schema.Types.String })
+  public refArrayStringOptional?: Ref<RefTestStringOptional, string>[];
+
+  @arrayProp({ ref: 'RefTestString', refType: mongoose.Schema.Types.String })
+  public refArrayStringOrUndefined?: Ref<RefTestStringOrUndefined, string>[];
 
   // ref number
   @prop({ ref: RefTestNumber, refType: mongoose.Schema.Types.Number })

--- a/test/tests/ref.test.ts
+++ b/test/tests/ref.test.ts
@@ -82,6 +82,52 @@ it('check reference with string _id', async () => {
   expect(Array.from(refArrayString)).toEqual([_id1, _id2]);
 });
 
+it('check reference with optional string _id [typegoose/typegoose#249]', async () => {
+  const id1 = 'testid3';
+  const id2 = 'testid4';
+
+  const refTypeTest = new RefTestModel();
+  refTypeTest.refFieldStringOptional = id1;
+  refTypeTest.refArrayStringOptional = [id1, id2];
+  refTypeTest.refFieldStringOptional = new RefTestStringModel();
+  refTypeTest.refArrayStringOptional = [new RefTestStringModel(), new RefTestStringModel()];
+
+  const { _id: _id1 } = await RefTestStringModel.create({ _id: id1 });
+  expect(_id1).toEqual(id1);
+  const { _id: _id2 } = await RefTestStringModel.create({ _id: id2 });
+  expect(_id2).toEqual(id2);
+
+  const { _id: refStringId } = await RefTestModel.create({ refFieldString: _id1 });
+  const { refFieldString } = await RefTestModel.findById(refStringId).exec();
+  expect(refFieldString).toEqual(_id1);
+  const { _id: refArrayId } = await RefTestModel.create({ refArrayString: [_id1, _id2] });
+  const { refArrayString } = await RefTestModel.findById(refArrayId).exec();
+  expect(Array.from(refArrayString)).toEqual([_id1, _id2]);
+});
+
+it('check reference with string or undefined _id [typegoose/typegoose#249]', async () => {
+  const id1 = 'testid5';
+  const id2 = 'testid6';
+
+  const refTypeTest = new RefTestModel();
+  refTypeTest.refFieldStringOrUndefined = id1;
+  refTypeTest.refArrayStringOrUndefined = [id1, id2];
+  refTypeTest.refFieldStringOrUndefined = new RefTestStringModel();
+  refTypeTest.refArrayStringOrUndefined = [new RefTestStringModel(), new RefTestStringModel()];
+
+  const { _id: _id1 } = await RefTestStringModel.create({ _id: id1 });
+  expect(_id1).toEqual(id1);
+  const { _id: _id2 } = await RefTestStringModel.create({ _id: id2 });
+  expect(_id2).toEqual(id2);
+
+  const { _id: refStringId } = await RefTestModel.create({ refFieldString: _id1 });
+  const { refFieldString } = await RefTestModel.findById(refStringId).exec();
+  expect(refFieldString).toEqual(_id1);
+  const { _id: refArrayId } = await RefTestModel.create({ refArrayString: [_id1, _id2] });
+  const { refArrayString } = await RefTestModel.findById(refArrayId).exec();
+  expect(Array.from(refArrayString)).toEqual([_id1, _id2]);
+});
+
 it('check reference with number _id', async () => {
   const id1 = 1234;
   const id2 = 5678;


### PR DESCRIPTION
When `Ref<RefClass>` was used on a class defined with an optional `_id?` property that was not of type `ObjectId`, the extracted type would be wrong.

See [TypeScript Playground](https://www.typescriptlang.org/play/?ssl=1&ssc=1&pln=36&pc=3#code/C4TwDgpgBA8gRgKwgY2ASQCZQLxQN5QDOA9gLYTAAWAlgHYDmAXFMAE4Cu0AvgNwBQoSFABC7AGZiIrHPl595EAB5hirYFAwoANgENW0QdABKEMQBVw0XLXak4UqAB8ibOvSexEKdFmeiJUvx8SipqLJawWhgmYgA8RgA0UGZQSsAQtBiEUDEWQrhGqYrpmdkEAPrUGMy5ljxQXFAA-DkA2gDklRjtALpQzPBIqJgAfDKFzmZBIarqmsi6+uFCMfFJKWkZWTmmeVY5RSXbeHxQZ1BdTTW7dXyNLQByxLQP7Fq6cFoQ8R1dvWMDLzDDBjAoeKbyPgLHSEbIAWWImi0AEF8KcLlUri5WG5+Fx5NDYVAEUjhGizl0AITMQiuBgediZUx0CAYPEE3REkkQLTkqD0YiImLUnZxbkokb8M4CoWmABMItW4uEkvkZzgOmiphFMCiSsRPORqvVmpiCoGetMsXFRvZUOetKgYkFzHFMhO0sFWrEzAARJQeVpiL6EuiZd65X6A+9g6H0RrvVHA7H46b5UmYyG7jwgA) for an example of the problem.

I've also added `tsc --noEmit` as a pre-test step in order to check for typescript compilation errors, [jest doesn't do it otherwise](https://github.com/kulshekhar/ts-jest/issues/250).

For the `string | undefined` case, the error only showed up if typescript strict mode was enabled. I couldn't enable it because of a lot of other issues in lots of other places, so the test doesn't catch it properly.