### PR TITLE
Fix query method decorator

### DIFF
--- a/src/queryMethod.ts
+++ b/src/queryMethod.ts
@@ -4,14 +4,20 @@ import { logger } from './logSettings';
 import type { Func, QueryMethodMap } from './types';
 
 /**
- * Define Options for the Class
- * @param options Options
- * @example Example:
- * ```
- *  @modelOptions({ schemaOptions: { timestamps: true } })
- *  class Name {}
+ * Adds a query method to schema.
  *
- *  // Note: The default Class "TimeStamps" can be used for type information and options already set
+ * @param func Query function
+ * @example
+ * ```ts
+ * function findByTitle(this: ReturnModelType<typeof Event>, title: string) {
+ *  return this.find({ title });
+ * }
+ *
+ * @queryMethod(findByTitle)
+ * class Event {
+ *  @prop()
+ *  public title: string;
+ * }
  * ```
  */
 export function queryMethod(func: Func) {

--- a/src/queryMethod.ts
+++ b/src/queryMethod.ts
@@ -17,7 +17,7 @@ import type { Func, QueryMethodMap } from './types';
 export function queryMethod(func: Func) {
   return (target: any) => {
     logger.info('Adding query method "%s" to %s', func.name, getName(target));
-    const queryMethods: QueryMethodMap = new Map(Reflect.getMetadata(DecoratorKeys.QueryMethod, target.constructor) ?? []);
+    const queryMethods: QueryMethodMap = new Map(Reflect.getMetadata(DecoratorKeys.QueryMethod, target) ?? []);
     queryMethods.set(func.name, func);
     Reflect.defineMetadata(DecoratorKeys.QueryMethod, queryMethods, target);
   };

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -406,19 +406,33 @@ it('should add query Methods', async () => {
   function findByName(this: ReturnModelType<typeof QueryMethods>, name: string) {
     return this.find({ name }); // important to not do an "await" and ".exec"
   }
+
+  function findByLastname(this: ReturnModelType<typeof QueryMethods>, lastname: string) {
+    return this.find({ lastname }); // important to not do an "await" and ".exec"
+  }
+
   @queryMethod(findByName)
+  @queryMethod(findByLastname)
   class QueryMethods {
     @prop({ required: true })
     public name: string;
+
+    @prop({ required: true })
+    public lastname: string;
   }
 
   const QueryMethodsModel = getModelForClass(QueryMethods);
-  const doc = await QueryMethodsModel.create({ name: 'hello' });
-
-  const found: DocumentType<QueryMethods>[] | null = await (QueryMethodsModel.find() as any).findByName('hello').exec();
-  assertion(isDocumentArray(found), new Error('Found is not an document array'));
-  expect(found[0].toObject()).toEqual(doc.toObject());
 
   const metadata: QueryMethodMap = Reflect.getMetadata(DecoratorKeys.QueryMethod, QueryMethods);
-  expect(Array.from(metadata)).toEqual([['findByName', findByName]]);
+  expect(Array.from(metadata)).toEqual(
+    expect.arrayContaining([['findByName', findByName]]) &&
+    expect.arrayContaining([['findByLastname', findByLastname]])
+  );
+
+  const doc = await QueryMethodsModel.create({ name: 'hello', lastname: 'world' });
+
+  const found: DocumentType<QueryMethods>[] | null =
+    await (QueryMethodsModel.find() as any).findByName('hello').findByLastname('world').exec();
+  assertion(isDocumentArray(found), new Error('Found is not an document array'));
+  expect(found[0].toObject()).toEqual(doc.toObject());
 });


### PR DESCRIPTION
This PR fixes getting metadata from a class for query methods.

I've hit the error when I tried to apply multiple query methods to a schema.

**Notes**
Moved metadata test before document creation to raise error in case metadata is not correct before doing anything else in the database.
