### PR TITLE
Imports the logger earlier to fix reference error

### DIFF
--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -9,6 +9,8 @@ if (semver.lt(mongoose.version, '5.9.14')) {
   throw new Error('Please use mongoose 5.9.14 or higher');
 }
 
+import { logger } from './logSettings';
+
 /* istanbul ignore next */
 if (semver.lt(process.version.slice(1), '10.15.0')) {
   logger.warn('You are using a NodeJS Version below 10.15.0, Please Upgrade!');
@@ -19,7 +21,6 @@ import { DecoratorKeys } from './internal/constants';
 import { constructors, models } from './internal/data';
 import { _buildSchema } from './internal/schema';
 import { assertion, assertionIsClass, getName, mergeMetadata, mergeSchemaOptions } from './internal/utils';
-import { logger } from './logSettings';
 import { isModel } from './typeguards';
 import type { AnyParamConstructor, DocumentType, IModelOptions, Ref, ReturnModelType } from './types';
 


### PR DESCRIPTION
The logic is trying to warn developer about the old node version using a logger, but the logger is not yet imported there. This causes a reference error instead of that warning.
This change moves the logger import before the check, so that it's in the scope when warning is happening and the logic proceeds correctly.

To verify: attempt to run the typegoose logic before and after the change on an older node version.

<!--
Try to use a template, found at .github/PULL_REQUEST_TEMPLATE/
[here](https://github.com/typegoose/typegoose/tree/master/.github/PULL_REQUEST_TEMPLATE)
please don't forget to click on raw, and copy that, not the already "compiled" one
-->

<!--
## Make sure you have done these steps

- Make sure you have Read & followed these steps in [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

## Misc

- [ ] Is this a prototype? <!--Is this PR already finished or not yet ready?-->
- [ ] Written Tests for it? <!--Written Tests for this feature / fix? (only if needed)-->
- [X] Already read & followed [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)?
