### PR TITLE
fix the DocumentType definition when the model extends Base<String>

### DIFF
--- a/src/internal/processProp.ts
+++ b/src/internal/processProp.ts
@@ -84,6 +84,11 @@ export function processProp(input: DecoratedPropertyMetadata): void {
     );
   }
 
+  // map to correct buffer type, otherwise it would result in "Mixed"
+  if (Type === mongoose.Types.Buffer) {
+    Type = mongoose.Schema.Types.Buffer;
+  }
+
   if (utils.isNotDefined(Type)) {
     buildSchema(Type);
   }

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -327,7 +327,12 @@ export function getName<U extends AnyParamConstructor<any>>(cl: U) {
  * @param cl The Type
  */
 export function isNotDefined(cl: any) {
-  return typeof cl === 'function' && !isPrimitive(cl) && cl !== Object && cl !== mongoose.Schema.Types.Buffer && !schemas.has(getName(cl));
+  return (
+    typeof cl === 'function'
+    && !isPrimitive(cl)
+    && cl !== Object
+    && !schemas.has(getName(cl))
+  );
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,9 @@ import type { Severity, WhatIsIt } from './internal/constants';
  * const t: DocumentType<Name> = await NameModel.create({} as Partitial<Name>);
  * ```
  */
-export type DocumentType<T> = (T extends Base<any> ? Omit<mongoose.Document, '_id'> & T : mongoose.Document & T) & IObjectWithTypegooseFunction;
+export type DocumentType<T> = (
+  T extends Base<any> ? Omit<mongoose.Document, '_id'> & T : mongoose.Document & T
+) & IObjectWithTypegooseFunction;
 // I tested "T & (T extends ? : )" already, but it didnt work out
 /**
  * Used Internally for ModelTypes
@@ -292,9 +294,10 @@ export type PropOptionsForString = BasePropOptions & TransformStringOptions & Va
 export type RefType =
   | number
   | string
-  | mongoose.Types.ObjectId
   | Buffer
   | undefined
+  | mongoose.Types.ObjectId
+  | mongoose.Types.Buffer
   | typeof mongoose.Schema.Types.Number
   | typeof mongoose.Schema.Types.String
   | typeof mongoose.Schema.Types.Buffer

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ import type { Severity, WhatIsIt } from './internal/constants';
  * const t: DocumentType<Name> = await NameModel.create({} as Partitial<Name>);
  * ```
  */
-export type DocumentType<T> = (T extends Base ? Omit<mongoose.Document, '_id'> & T : mongoose.Document & T) & IObjectWithTypegooseFunction;
+export type DocumentType<T> = (T extends Base<any> ? Omit<mongoose.Document, '_id'> & T : mongoose.Document & T) & IObjectWithTypegooseFunction;
 // I tested "T & (T extends ? : )" already, but it didnt work out
 /**
  * Used Internally for ModelTypes

--- a/test/models/refTests.ts
+++ b/test/models/refTests.ts
@@ -2,7 +2,7 @@ import { getModelForClass, getName, mongoose, prop, Ref } from '../../src/typego
 
 export class RefTestBuffer {
   @prop()
-  public _id!: mongoose.Schema.Types.Buffer;
+  public _id!: mongoose.Types.Buffer;
 }
 
 export class RefTestNumber {
@@ -88,17 +88,17 @@ export class RefTest {
 
   // ref buffer
   @prop({ ref: RefTestBuffer, type: mongoose.Schema.Types.Buffer })
-  public refFieldBuffer?: Ref<RefTestBuffer, Buffer>;
+  public refFieldBuffer?: Ref<RefTestBuffer, mongoose.Types.Buffer | Buffer>;
 
   @prop({ ref: getName(RefTestBuffer), type: mongoose.Schema.Types.Buffer })
-  public refFieldBuffer2?: Ref<RefTestBuffer, Buffer>;
+  public refFieldBuffer2?: Ref<RefTestBuffer, mongoose.Types.Buffer | Buffer>;
 
   // ref buffer array
   @prop({ ref: RefTestBuffer, type: mongoose.Schema.Types.Buffer })
-  public refArrayBuffer?: Ref<RefTestBuffer, Buffer>[];
+  public refArrayBuffer?: Ref<RefTestBuffer, mongoose.Types.Buffer | Buffer>[];
 
   @prop({ ref: getName(RefTestBuffer), type: mongoose.Schema.Types.Buffer })
-  public refArrayBuffer2?: Ref<RefTestBuffer, Buffer>[];
+  public refArrayBuffer2?: Ref<RefTestBuffer, mongoose.Types.Buffer | Buffer>[];
 }
 
 export const RefTestModel = getModelForClass(RefTest);

--- a/test/tests/ref.test.ts
+++ b/test/tests/ref.test.ts
@@ -1,7 +1,7 @@
 import * as mongoose from 'mongoose';
 
 import { assertion, getName } from '../../src/internal/utils';
-import { getModelForClass, isDocument, isDocumentArray, prop, Ref } from '../../src/typegoose';
+import { getModelForClass, isDocument, isDocumentArray, isRefType, prop, Ref } from '../../src/typegoose';
 import { RefTestArrayTypesModel, RefTestBufferModel, RefTestModel, RefTestNumberModel, RefTestStringModel } from '../models/refTests';
 
 it('check generated ref schema for ObjectID _id', async () => {
@@ -169,6 +169,7 @@ it('check reference with buffer _id', async () => {
 
   const { _id: refBufferId } = await RefTestModel.create({ refFieldBuffer: _id1 });
   const { refFieldBuffer } = await RefTestModel.findById(refBufferId).orFail().exec();
+  assertion(isRefType(refFieldBuffer), new Error('Expected "refFieldBuffer" to be "mongoose.Types.Buffer | Buffer"'));
   expect(_id1.equals(refFieldBuffer)).toEqual(true);
   const { _id: refArrayId } = await RefTestModel.create({ refArrayBuffer: [_id1, _id2] });
   const { refArrayBuffer } = await RefTestModel.findById(refArrayId).orFail().exec();


### PR DESCRIPTION
If the model class extends with the `Base<string>`, the `DocumentType` definition is bad because the conditional type uses `Base` instead of `Base<any>`. The default value for the generic of `Base` class is `ObjectId` so the test in conditional type is `T extends Base<ObjectId>`.

```typescript
class Test extends Base<string> {}
const TestModel = getModelForClass(Test);
const test = new TestModel();
test._id; // <= _id have the any type instead of string
```