### PR TITLE
docs: document use of type option with arrays

### DIFF
--- a/github-page/_docs/decorators/prop.md
+++ b/github-page/_docs/decorators/prop.md
@@ -241,6 +241,15 @@ Accepts Type: `any | () => any`
 
 Overwrite the type that is got from the `design:type` reflection
 
+Example: Arrays (array item types can't be automatically inferred via Reflect)
+
+```ts
+class Dummy {
+  @prop({ type: String })
+  public hello: string[];
+}
+```
+
 Example: get as `string[]`, save as `string`
 
 ```ts


### PR DESCRIPTION
The documentation of the `type` option in the `@prop` decorator suggests that it is only necessary in edge cases. However, with the deprecation of `@arrayProp`, this option will become *mandatory* for any array properties.

This PR makes that clear, to avoid other developers debugging something that is a known behavior that can't be fixed.

## Related Issues

- #300 
- #318 
- #321