### PR TITLE
added missing empty object for assign operation after hours of debugg…

### DIFF
--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -49,7 +49,7 @@ export function _buildSchema<U extends AnyParamConstructor<any>>(
   /** Simplify the usage */
   const Schema = mongoose.Schema;
   const ropt: IModelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, cl) ?? {};
-  const schemaOptions = Object.assign(ropt?.schemaOptions ?? {}, opt);
+  const schemaOptions = Object.assign({}, ropt?.schemaOptions ?? {}, opt);
 
   const decorators = Reflect.getMetadata(DecoratorKeys.PropCache, cl.prototype) as DecoratedPropertyMetadataMap;
 
@@ -79,12 +79,15 @@ export function _buildSchema<U extends AnyParamConstructor<any>>(
       for (const [key, discriminators] of disMap) {
         logger.debug('Applying Nested Discriminators for:', key, discriminators);
 
-        const path: { discriminator?: Func; } = sch.path(key) as any;
+        const path: { discriminator?: Func } = sch.path(key) as any;
         assertion(!isNullOrUndefined(path), new Error(`Path "${key}" does not exist on Schema of "${name}"`));
-        assertion(typeof path.discriminator === 'function', new Error(`There is no function called "discriminator" on schema-path "${key}" on Schema of "${name}"`));
+        assertion(
+          typeof path.discriminator === 'function',
+          new Error(`There is no function called "discriminator" on schema-path "${key}" on Schema of "${name}"`)
+        );
 
         for (const { type: child, value: childName } of discriminators) {
-          const childSch = getName(child) === name ? sch : buildSchema(child) as mongoose.Schema & { paths: any; };
+          const childSch = getName(child) === name ? sch : (buildSchema(child) as mongoose.Schema & { paths: any });
 
           const discriminatorKey = childSch.get('discriminatorKey');
           if (childSch.path(discriminatorKey)) {

--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -79,7 +79,7 @@ export function _buildSchema<U extends AnyParamConstructor<any>>(
       for (const [key, discriminators] of disMap) {
         logger.debug('Applying Nested Discriminators for:', key, discriminators);
 
-        const path: { discriminator?: Func } = sch.path(key) as any;
+        const path: { discriminator?: Func; } = sch.path(key) as any;
         assertion(!isNullOrUndefined(path), new Error(`Path "${key}" does not exist on Schema of "${name}"`));
         assertion(
           typeof path.discriminator === 'function',
@@ -87,7 +87,7 @@ export function _buildSchema<U extends AnyParamConstructor<any>>(
         );
 
         for (const { type: child, value: childName } of discriminators) {
-          const childSch = getName(child) === name ? sch : (buildSchema(child) as mongoose.Schema & { paths: any });
+          const childSch = getName(child) === name ? sch : (buildSchema(child) as mongoose.Schema & { paths: any; });
 
           const discriminatorKey = childSch.get('discriminatorKey');
           if (childSch.path(discriminatorKey)) {


### PR DESCRIPTION
Hello there,

I had a long debugging session to find a strange bug, and finally found the missing part.
There was a schemaOptions overwriting to the ancestor thought prototype chain
We have a package that contains our Base model classes, and multiple packages to use it.
One of them was using @modelOptions decorator to set custom collection name

```ts
@modelOptions({
    schemaOptions: {
        strict: "throw",
        collection: "transactions",
    },
})
export class QueueTransaction extends TypegooseBase {
```

after building a schema for this model, any future schemas would have the same schemaOptions.

Outputs are below, before and after the fix

before fix
```
@theproject: _buildSchema Called for TypegooseBase with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for VXBase with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for TypegooseWithoutTimestamp with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for Base with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for QueueTransaction with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: Starting to process "QueueTransaction.request_id"
@theproject: Starting to process "QueueTransaction.user"
@theproject: _buildSchema Called for TypegooseBase with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for VXBase with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for TypegooseWithoutTimestamp with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for Base with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for QueueTransactionUser with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: Starting to process "QueueTransactionUser.source_id"
@theproject: _buildSchema Called for TypegooseBase with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for VXBase with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for TypegooseWithoutTimestamp with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for Base with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for QueueTransactionUser with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: Starting to process "QueueTransactionUser.source_id"
@theproject: Starting to process "QueueTransaction.payload"
@theproject: Prop Option "type" is set to [Function: Object]
@theproject: mapOptions called
@theproject: Converting "Object" to mongoose Type
@theproject: The Type "Object" has a property "OptionsConstructor" but it does not extend "SchemaTypeOptions
@theproject: Final mapped Options for Type "Object" { inner: {}, outer: {} }
@theproject: Class "QueueTransaction" already existed in the constructors Map
@theproject: _buildSchema Called for TypegooseBase with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for VXBase with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for TypegooseWithoutTimestamp with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for Base with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for Request with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: Starting to process "Request.organization"
@theproject: Starting to process "Request.summary"
@theproject: Starting to process "Request.details"
@theproject: Starting to process "Request.attachments"
@theproject: mapArrayOptions called
@theproject: mapOptions called
@theproject: Converting "Array" to mongoose Type
@theproject: Final mapped Options for Type "Array" { inner: {}, outer: { required: true } }
@theproject: createArrayFromDimensions called with 1 dimensions
@theproject: (Array) Final mapped Options for Type "Array" { required: true, type: [ { type: [Function: Array] } ] }
@theproject: Starting to process "Request.createdAt"
@theproject: Starting to process "Request.resolvedAt"
@theproject: Starting to process "Request.status"
@theproject: Class "Request" already existed in the constructors Map
```

after fix
```
@theproject: _buildSchema Called for TypegooseBase with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for VXBase with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for TypegooseWithoutTimestamp with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for Base with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: _buildSchema Called for QueueTransaction with options: { timestamps: true, strict: 'throw', collection: 'transactions' }
@theproject: Starting to process "QueueTransaction.request_id"
@theproject: Starting to process "QueueTransaction.user"
@theproject: _buildSchema Called for TypegooseBase with options: { timestamps: true }
@theproject: _buildSchema Called for VXBase with options: { timestamps: true }
@theproject: _buildSchema Called for TypegooseWithoutTimestamp with options: { timestamps: true }
@theproject: _buildSchema Called for Base with options: { timestamps: true }
@theproject: _buildSchema Called for QueueTransactionUser with options: { timestamps: true }
@theproject: Starting to process "QueueTransactionUser.source_id"
@theproject: _buildSchema Called for TypegooseBase with options: { timestamps: true }
@theproject: _buildSchema Called for VXBase with options: { timestamps: true }
@theproject: _buildSchema Called for TypegooseWithoutTimestamp with options: { timestamps: true }
@theproject: _buildSchema Called for Base with options: { timestamps: true }
@theproject: _buildSchema Called for QueueTransactionUser with options: { timestamps: true }
@theproject: Starting to process "QueueTransactionUser.source_id"
@theproject: Starting to process "QueueTransaction.payload"
@theproject: Prop Option "type" is set to [Function: Object]
@theproject: mapOptions called
@theproject: Converting "Object" to mongoose Type
@theproject: The Type "Object" has a property "OptionsConstructor" but it does not extend "SchemaTypeOptions
@theproject: Final mapped Options for Type "Object" { inner: {}, outer: {} }
@theproject: Class "QueueTransaction" already existed in the constructors Map
@theproject: _buildSchema Called for TypegooseBase with options: { timestamps: true }
@theproject: _buildSchema Called for VXBase with options: { timestamps: true }
@theproject: _buildSchema Called for TypegooseWithoutTimestamp with options: { timestamps: true }
@theproject: _buildSchema Called for Base with options: { timestamps: true }
@theproject: _buildSchema Called for Request with options: { timestamps: true }
@theproject: Starting to process "Request.organization"
@theproject: Starting to process "Request.summary"
@theproject: Starting to process "Request.details"
@theproject: Starting to process "Request.attachments"
@theproject: mapArrayOptions called
@theproject: mapOptions called
@theproject: Converting "Array" to mongoose Type
@theproject: Final mapped Options for Type "Array" { inner: {}, outer: { required: true } }
@theproject: createArrayFromDimensions called with 1 dimensions
@theproject: (Array) Final mapped Options for Type "Array" { required: true, type: [ { type: [Function: Array] } ] }
@theproject: Starting to process "Request.createdAt"
@theproject: Starting to process "Request.resolvedAt"
@theproject: Starting to process "Request.status"
@theproject: Class "Request" already existed in the constructors Map
```

## Collection of what it does / fixes

- it fixes overwriting of schema Options to the ancestor in prototype

