### PR TITLE
Fix Ref type always accepting undefined

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -314,7 +314,7 @@ export type RefType =
 // export type Ref<R, T extends RefType = mongoose.Types.ObjectId> = R | T; // old type, kept for easy revert
 export type Ref<
   R,
-  T extends RefType = (R extends { _id?: RefType; } ? NonNullable<R['_id']> : mongoose.Types.ObjectId) | undefined
+  T extends RefType = R extends { _id?: RefType; } ? NonNullable<R['_id']> : mongoose.Types.ObjectId
   > = R | T;
 
 /**


### PR DESCRIPTION
<!--
Try to use a template, found at .github/PULL_REQUEST_TEMPLATE/
[here](https://github.com/typegoose/typegoose/tree/master/.github/PULL_REQUEST_TEMPLATE)
please don't forget to click on raw, and copy that, not the already "compiled" one
-->

<!--
## Make sure you have done these steps

- Make sure you have Read & followed these steps in [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

The type `Ref` always accepts undefined, which causes a typescript error when trying to access directly to a required property with type Ref.

I created a reproduction of the bug in [TypeScript Playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBA8gRgKwgY2ASQCZQLxQN4C+A3AFCiRQBCArgGa0QBOO+xJJEAHmAPaPBQMKADYBDRtHLQAShFoAVcNFwA7agFs4TKAB8oAZ2CMAlioDmuqnQbM91FUNqmIWPfCSpMpEgHofUAGFqRgkVAWN1MGEIdQgw0WBjHhUALigAC2BgMH0UvzNjYHTqOAA6ZB51HykzHh59CGqlWvrGuGEeOB8AVgAmAEZ+gGZaZGHegHZ+gBZRZG6MAE4XAAZplAwADjheiDh+3uRafsWh6bhNn31GZCbIfVLgfQBiABkh-u6Obj4BKVhhBhZLQADwkKBQaQAGnBUHkUC4wDiGH0kLkigouAAFNIEZwkQ5UXgoAB9YwYAD8aWBGIgRCgBCgFKgADlkizqMIxO0ICDpABtADkZIwgoAugA+KBpdwodAYACUlnsjmcGFhUtwuL08m8figAAVGDxeA0sBEojE4sAEkkVFAsRJ1DwAG4QVFFaD2O1QADuhXSUBVcjVCu+vH4ghE4kkSlZEF9wLBEOhsPhiORqJpca1eIJKPwpPJVLRCiU9MZzLZKg5XNEPL5QpF4qlMsQcswGpY2rh3mQYn0qIAsjwhMJgfhYSKS7LPK4DEZTGZSAR2P3RIOAUC5COx5OISbEslROO5DPAUndxBT7QJaQIRIAI7UYwSbe0ACEMovchBV5vd4kKuJDrpuLIJsC-77lAh52iewIluBia-v+wKAQ+EDPq+LjAl+8bIaCqFyIBwEVCohgwT+tDfu+UG4HgsKwceN5pAARLQdSsTCGFYW+wJsXA4isUBfbJBRKgQXIaRIZBo7XiwDEHmAR4qPBUlQOxnHcVAT4vnx6msYJjDCWwJA8FRpRMapN6PDwADKi7mFiSr6hUIRylCMHKXBN5QMgoj2loQYOCGEnquZ76lLp2GRcA9mOWYzlQPqphuRIqCedF+m0H5AUqDwAhBcGThhewEkEZZ3nMcCtkOSYTkuf4aUeV5KlqTl-mBV6IUlS4JDlTVWU4XItUJUlrl8OlwCZZhenDR1eUFVARU9Wq7AkEAA).

Given a class with required and optional references, typescript should only throw an error if the optional reference is accessed without checking, but the current implementation forces both to be checked (since Ref always accept undefined, even for required properties).

```ts
class Entity {
  ref1?: Ref<AnotherEntity>
  ref2!: Ref<AnotherEntity>
}

const entity: Entity
entity.ref1.toString() // before and after this PR it throws an error because ref1 can be undefined.
entity.ref2.toString() // before this PR it incorrectly throws an error saying ref2 can be undefined.
                       //        After this PR it won't throw errors because ref2 cannot be undefined.
```

All tests are passing after this PR:

```
% npm test
Test Suites: 22 passed, 22 total
Tests:       196 passed, 196 total
Snapshots:   1 passed, 1 total
Time:        5.695 s, estimated 15 s
Ran all test suites
```