### PR TITLE
Update hooks.md

### DIFF
--- a/docs/api/decorators/hooks.md
+++ b/docs/api/decorators/hooks.md
@@ -3,6 +3,14 @@ id: hooks
 title: 'Hooks'
 ---
 
+> Don't forget to import these hooks with:
+
+```ts
+import { pre, post } from '@typegoose/typegoose';
+```
+
+---
+
 ## @pre
 
 `@pre<T>(name: string | string[] | regexp | regexp[], method: () => any)` is used to set Pre-Hooks
@@ -50,8 +58,3 @@ class Car {
 ```
 
 
-> Don't forget to import these hooks with:
-
-```ts
-import { pre, post } from '@typegoose/typegoose';
-```

--- a/docs/api/decorators/hooks.md
+++ b/docs/api/decorators/hooks.md
@@ -48,3 +48,10 @@ class Car {
   public topSpeedInKmH!: number;
 }
 ```
+
+
+> Don't forget to import these hooks with:
+
+```ts
+import { pre, post } from '@typegoose/typegoose';
+```


### PR DESCRIPTION
Tiny minor change to docs remind people to import the `pre, post` hooks. I made the mistake, maybe someone else will too. 
I thought the 'pre' decorator was a language feature, not a specific decorator to import.

![image](https://user-images.githubusercontent.com/514002/100281332-90374e00-2f1e-11eb-9897-e9a12e05127a.png)

<!--Write your PR description here (above "Related Issues")-->

## Related Issues
- fixes https://github.com/typegoose/typegoose/issues/415
