### PR TITLE
docs(virtuals): improved description of ref option

### DIFF
--- a/docs/api/virtuals.md
+++ b/docs/api/virtuals.md
@@ -58,7 +58,7 @@ Virtual-Populate is also supported by Typegoose
 
 Options ([look here for more details](https://mongoosejs.com/docs/api/schema.html#schema_Schema-virtual)):
 
-- `ref`: This is like a normal ref **[Required]**
+- `ref`: This is like a normal [ref](https://typegoose.github.io/typegoose/docs/api/decorators/prop/#ref), use `'ClassName'` when the classes are in different files **[Required]**
 - `foreignField`: Which property(on the ref-Class) to match `localField` against **[Required]**
 - `localField`: Which property(on the current-Class) to match `foreignField` against **[Required]**
 - `justOne`: Return as One Document(true) or as Array(false) ***[Optional]***


### PR DESCRIPTION
I read the docs about how to create virtual populate and ran into the same issues as described in #427. 
As far as I can see, circular dependencies can't be solved when using different classes.
So I thought it could be useful to update the docs with a better description by adding a link to the [ref doc](https://typegoose.github.io/typegoose/docs/api/decorators/prop/#ref) and adding the hint that one should use `'ClassName'` when the classes are in different files.

## Related Issues
- fixes #427 (not a real fix, but prevents future 'bug' reports)