### PR TITLE
Mongoose version diagnostic info.

### DIFF
--- a/docs/guides/error-warnings-details.md
+++ b/docs/guides/error-warnings-details.md
@@ -7,7 +7,7 @@ title: "Error & Warning Details"
 
 ### Mongoose Version [E001]
 
-Error: `Please use mongoose 5.9.14 or higher [E001]`
+Error: `Using mongoose <old-version>. Please use mongoose 5.9.14 or higher [E001]`
 
 Details:  
 Typegoose requires at least mongoose version 5.9.14, because that version changed something that affected typegoose internals

--- a/docs/guides/error-warnings-details.md
+++ b/docs/guides/error-warnings-details.md
@@ -7,7 +7,7 @@ title: "Error & Warning Details"
 
 ### Mongoose Version [E001]
 
-Error: `Using mongoose <old-version>. Please use mongoose 5.9.14 or higher [E001]`
+Error: `Please use mongoose 5.9.14 or higher (Current mongoose: x.x.x) [E001]`
 
 Details:  
 Typegoose requires at least mongoose version 5.9.14, because that version changed something that affected typegoose internals

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -9,7 +9,7 @@ import { assertion, assertionIsClass, getName, isNullOrUndefined, mergeMetadata,
 if (!isNullOrUndefined(process?.version) && !isNullOrUndefined(mongoose?.version)) { // for usage on client side
   /* istanbul ignore next */
   if (semver.lt(mongoose?.version, '5.9.14')) {
-    throw new Error(`Using mongoose ${mongoose.version}. Please use mongoose 5.9.14 or higher [E001]`);
+    throw new Error(`Please use mongoose 5.9.14 or higher (Current mongoose: ${mongoose.version}) [E001]`);
   }
 
   /* istanbul ignore next */

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -9,7 +9,7 @@ import { assertion, assertionIsClass, getName, isNullOrUndefined, mergeMetadata,
 if (!isNullOrUndefined(process?.version) && !isNullOrUndefined(mongoose?.version)) { // for usage on client side
   /* istanbul ignore next */
   if (semver.lt(mongoose?.version, '5.9.14')) {
-    throw new Error('Please use mongoose 5.9.14 or higher [E001]');
+    throw new Error(`Using mongoose ${mongoose.version}. Please use mongoose 5.9.14 or higher [E001]`);
   }
 
   /* istanbul ignore next */


### PR DESCRIPTION
<!--
## Make sure you have done these steps

- Make sure you have Read & followed these steps in [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

<!--Write your PR description here (above "Related Issues")-->
 
I was having some issues with my bundler (not typegoose's fault) and it would have been nice to have some diagnostic info about _why_ we were getting the wrong version. This adds the version seen to the error message about incorrect versions.

## What does the Feature do

Adds a bit of diagnostic info to the E001 error message.
