### PR TITLE
fix invalide default function example

### DIFF
--- a/docs/api/decorators/prop.md
+++ b/docs/api/decorators/prop.md
@@ -79,11 +79,13 @@ Example:
 
 ```ts
 class Defaulted {
-  @prop({ required: true }) firstName!: string
-  @prop({ required: true }) lastName!: string
+  @prop({ required: true })
+  firstName!: string
+  @prop({ required: true })
+  lastName!: string
   
   @prop({ 
-    default (this: DocumentType<Defaulted>) {
+    default: function (this: DocumentType<Defaulted>) {
       return `${this.firstName} ${this.lastName}`
     }
   })

--- a/docs/api/decorators/prop.md
+++ b/docs/api/decorators/prop.md
@@ -79,6 +79,9 @@ Example:
 
 ```ts
 class Defaulted {
+  @prop({ required: true }) firstName!: string
+  @prop({ required: true }) lastName!: string
+  
   @prop({ 
     default (this: DocumentType<Defaulted>) {
       return `${this.firstName} ${this.lastName}`

--- a/docs/api/decorators/prop.md
+++ b/docs/api/decorators/prop.md
@@ -80,7 +80,7 @@ Example:
 ```ts
 class Defaulted {
   @prop({ 
-    default: (this: DocumentType<Defaulted>) => {
+    default (this: DocumentType<Defaulted>) {
       return `${this.firstName} ${this.lastName}`
     }
   })


### PR DESCRIPTION
https://typegoose.github.io/typegoose/docs/api/decorators/prop/#default
the current default function example is invalid (using an arrow function)
arrow functions cant have this parameters
![image](https://user-images.githubusercontent.com/24187269/103140393-6b352700-46e6-11eb-95a8-22ef4a64aacc.png)

---
besides that, mongoose won't be able to bind `this` correctly if an arrow function is used instead of a function expression.

the example has to be either 
```ts
  @prop({ 
    default (this: DocumentType<User>) { 
      return `${this.firstName} ${this.lastName}`
    } 
  }) fullName?: string
```
(why this is valid js https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions)

---
or the more verbose variant 
```ts
  @prop({ 
    default: function (this: DocumentType<User>) { 
      return `${this.firstName} ${this.lastName}`
    } 
  }) fullName?: string
```
