### PR TITLE
Update to be compatible with mongoose@5.11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,7 @@ class User {
 
 - TypeScript `^3.9` (since 7.1)
 - NodeJS `^10.15.0`
-- Mongoose `5.10.18` ([look here for why this version]([./faq.md#why-is-74x-constrained-to-mongoose-51018](https://typegoose.github.io/typegoose/docs/guides/faq#why-is-74x-constrained-to-mongoose-51018)))
-- `@types/mongoose` `5.10.x`
+- Mongoose `5.11.19` ([look here for why this version]([./faq.md#why-is-74x-constrained-to-mongoose-51018](https://typegoose.github.io/typegoose/docs/guides/faq#why-is-74x-constrained-to-mongoose-51018)))
 - `experimentalDecorators` and `emitDecoratorMetadata` must be enabled in `tsconfig.json`
 - tsconfig option `target` being `ES6`
 

--- a/docs/guides/error-warnings-details.md
+++ b/docs/guides/error-warnings-details.md
@@ -7,10 +7,10 @@ title: "Error & Warning Details"
 
 ### Mongoose Version [E001]
 
-Error: `Please use mongoose 5.10.0 or higher (Current mongoose: x.x.x) [E001]`
+Error: `Please use mongoose 5.11.19 or higher (Current mongoose: x.x.x) [E001]`
 
 Details:  
-Typegoose requires at least mongoose version 5.10.0, because that version changed something that affected typegoose internals
+Typegoose requires at least mongoose version 5.11.19, because that version changed something that affected typegoose internals
 
 ### NodeJS Version [E002]
 

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -32,14 +32,6 @@ A: because I (hasezoey) don't have permissions over the old `typegoose` reposito
 
 A: because Typegoose doesn't modify any Mongoose code, it is still the same as Mongoose's original `new Model()`, you would have to do `new Model({} as Class)` (or sometimes `new Model({} as Partial<Class>)`, because of functions.)
 
-:::note
-since `@types/mongoose@5.7.22` there are typings for `.create`, but are not fully compatible with Typegoose. For more information please read [known-issues](guides/known-issues.md#typesmongoose5722-and-higher)
-:::
-
-### Why is 7.4.x constrained to mongoose 5.10.18?
-
-A: this because in mongoose 5.10.19 and higher, mongoose has its own typescript definitions, and typegoose is not upgraded for that yet
-
 ## Edge Cases
 
 ### I want to the return document with property `id` instead of `_id`

--- a/docs/guides/known-issues.md
+++ b/docs/guides/known-issues.md
@@ -76,11 +76,3 @@ class Parent {
   public subDoc: Sub;
 }
 ```
-
-### @types/mongoose@5.7.22 and higher
-
-Since `@types/mongoose@5.7.22`, there are types for `.create`, but they are not fully compatible with Typegoose's types. So if an error comes up that cannot be fixed, the workaround is to use `<any>`
-
-```ts
-model.create<any>({ anything: anything });
-```

--- a/docs/guides/mongoose-compatibility.csv
+++ b/docs/guides/mongoose-compatibility.csv
@@ -1,4 +1,5 @@
 Typegoose Version,Mongoose Version
+8.0.x,^5.11.19
 7.4.x,5.10.0 - 5.10.18
 7.3.x,^5.9.22
 7.2.x,^5.9.17

--- a/docs/guides/mongoose-compatibility.md
+++ b/docs/guides/mongoose-compatibility.md
@@ -8,6 +8,7 @@ title: "Mongoose Compatibility"
 <!--Everything below here is generated as stated above-->
 | Typegoose Version | Mongoose Version |
 | ----------------- | ---------------- |
+| 8.0.x             | ^5.11.19         |
 | 7.4.x             | 5.10.0 - 5.10.18 |
 | 7.3.x             | ^5.9.22          |
 | 7.2.x             | ^5.9.17          |

--- a/docs/guides/quick-start-guide.md
+++ b/docs/guides/quick-start-guide.md
@@ -100,8 +100,7 @@ class User {
 
 - TypeScript `^3.9` (since 7.1)
 - NodeJS `^10.15.0`
-- Mongoose `5.10.18` ([look here for why this version](./faq.md#why-is-74x-constrained-to-mongoose-51018))
-- `@types/mongoose` `5.10.x`
+- Mongoose `5.11.19`
 - An IDE that supports TypeScript linting (VSCode is recommended)
 - This Guide expects you to know how Mongoose (or at least its models) works
 - `experimentalDecorators` and `emitDecoratorMetadata` must be enabled in `tsconfig.json`
@@ -113,7 +112,12 @@ class User {
 npm i -s @typegoose/typegoose # install typegoose itself
 
 npm i -s mongoose # install peer-dependency mongoose
-npm i -D @types/mongoose # install all types for mongoose - this is required for typegoose to work in TypeScript
+```
+
+```sh
+yarn add @typegoose/typegoose # install typegoose itself
+
+yarn add mongoose # install peer-dependency mongoose
 ```
 
 ### How to use Typegoose

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@types/mongoose": "^5.10.2",
-    "mongoose": "5.10.0 - 5.10.18"
+    "mongoose": "^5.11.19"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.0.1",
@@ -48,7 +47,6 @@
     "@commitlint/config-conventional": "^12.0.1",
     "@types/jest": "^26.0.20",
     "@types/lodash": "^4.14.161",
-    "@types/mongoose": "^5.10.2",
     "@types/node": "^10.17.16",
     "@types/semver": "^7.3.4",
     "@typescript-eslint/eslint-plugin": "^4.15.2",
@@ -63,7 +61,7 @@
     "jest": "^26.6.3",
     "lint-staged": "^10.5.4",
     "mongodb-memory-server": "^6.9.3",
-    "mongoose": "5.10.0 - 5.10.18",
+    "mongoose": "^5.11.19",
     "mongoose-findorcreate": "^3.0.0",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",

--- a/src/defaultClasses.ts
+++ b/src/defaultClasses.ts
@@ -12,12 +12,14 @@ export abstract class TimeStamps {
 }
 
 /**
- * This class provied the basic mongoose document properties
+ * This Interface can be used when "_id" and "id" need to be defined in types
  */
-export abstract class Base<T_ID extends RefType = Types.ObjectId> {
-  public _id: T_ID;
-  public __v?: number;
-  public __t?: string | number;
+export interface Base<IDType extends RefType = Types.ObjectId> {
+  _id: IDType;
+  /**
+   * This getter/setter dosnt exist if "schemaOptions.id" being set to "false"
+   */
+  id: string;
 }
 
 export interface FindOrCreateResult<T> {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -14,7 +14,7 @@ type HookNextErrorFn = (err?: Error) => ReturnVoid;
 
 type PreFnWithAggregate<T> = (this: Aggregate<T>, next: (error?: Error) => ReturnVoid, done: EmptyVoidFn) => ReturnVoid;
 type PreFnWithDocumentType<T> = (this: DocumentType<T>, next: HookNextErrorFn) => ReturnVoid;
-type PreFnWithQuery<T> = (this: Query<T>, next: (error?: Error) => ReturnVoid, done: EmptyVoidFn) => ReturnVoid;
+type PreFnWithQuery<T> = (this: Query<any, DocumentType<T>>, next: (error?: Error) => ReturnVoid, done: EmptyVoidFn) => ReturnVoid;
 
 type ModelPostFn<T> = (result: any, next: EmptyVoidFn) => ReturnVoid;
 

--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -30,7 +30,7 @@ import { assertion, assertionIsClass, assignGlobalModelOptions, getName, isNullO
  */
 export function _buildSchema<U extends AnyParamConstructor<any>>(
   cl: U,
-  sch?: mongoose.Schema,
+  sch?: mongoose.Schema<any>,
   opt?: mongoose.SchemaOptions,
   isFinalSchema: boolean = true
 ) {
@@ -87,7 +87,7 @@ export function _buildSchema<U extends AnyParamConstructor<any>>(
         );
 
         for (const { type: child, value: childName } of discriminators) {
-          const childSch = getName(child) === name ? sch : (buildSchema(child) as mongoose.Schema & { paths: any });
+          const childSch = getName(child) === name ? sch : buildSchema(child);
 
           const discriminatorKey = childSch.get('discriminatorKey');
 

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -455,7 +455,7 @@ export function mapOptions(
 
   // Fix because "Schema" is not a valid type and doesn't have a ".prototype.OptionsConstructor"
   if (Type instanceof mongoose.Schema) {
-    // TODO: remove "as any" cast if "OptionsConstructor" is implemented in @types/mongoose
+    // TODO: remove "as any" cast if "OptionsConstructor" is implemented in mongoose https://github.com/Automattic/mongoose/issues/10001
     OptionsCTOR = (mongoose as any).Schema.Types.Embedded.prototype.OptionsConstructor;
   }
 
@@ -468,7 +468,7 @@ export function mapOptions(
   delete options.items;
 
   // "mongoose as any" is because the types package does not yet have an entry for "SchemaTypeOptions"
-  // TODO: remove "as any" cast if "OptionsConstructor" is implemented in @types/mongoose
+  // TODO: remove "as any" cast if "OptionsConstructor" is implemented in mongoose https://github.com/Automattic/mongoose/issues/10001
   if (OptionsCTOR.prototype instanceof (mongoose as any).SchemaTypeOptions) {
     for (const [key, value] of Object.entries(options)) {
       if (Object.getOwnPropertyNames(OptionsCTOR.prototype).includes(key)) {

--- a/src/queryMethod.ts
+++ b/src/queryMethod.ts
@@ -1,4 +1,4 @@
-import type { DocumentQuery } from 'mongoose';
+import type { Query } from 'mongoose';
 import { DecoratorKeys } from './internal/constants';
 import { getName } from './internal/utils';
 import { logger } from './logSettings';
@@ -28,7 +28,7 @@ import type { AnyParamConstructor, QueryMethodMap, ReturnModelType } from './typ
  * ```
  */
 export function queryMethod<QueryHelpers, U extends AnyParamConstructor<any>>(
-  func: (this: ReturnModelType<U, QueryHelpers>, ...params: any[]) => DocumentQuery<any, any>
+  func: (this: ReturnModelType<U, QueryHelpers>, ...params: any[]) => Query<any, any>
 ): ClassDecorator {
   return (target: any) => {
     logger.info('Adding query method "%s" to %s', func.name, getName(target));

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -8,18 +8,13 @@ import { assertion, assertionIsClass, getName, isNullOrUndefined, mergeMetadata,
 if (!isNullOrUndefined(process?.version) && !isNullOrUndefined(mongoose?.version)) {
   // for usage on client side
   /* istanbul ignore next */
-  if (semver.lt(mongoose?.version, '5.10.0')) {
-    throw new Error(`Please use mongoose 5.10.0 or higher (Current mongoose: ${mongoose.version}) [E001]`);
+  if (semver.lt(mongoose?.version, '5.11.19')) {
+    throw new Error(`Please use mongoose 5.11.19 or higher (Current mongoose: ${mongoose.version}) [E001]`);
   }
 
   /* istanbul ignore next */
   if (semver.lt(process.version.slice(1), '10.15.0')) {
     throw new Error('You are using a NodeJS Version below 10.15.0, Please Upgrade! [E002]');
-  }
-
-  /* istanbul ignore next */
-  if (semver.gt(mongoose?.version, '5.10.18')) {
-    console.warn(`Using Unsupported mongoose version, highest supported is 5.10.18 (Current version: ${mongoose.version})`);
   }
 }
 

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -116,14 +116,14 @@ export function getModelWithString<U extends AnyParamConstructor<any>>(key: stri
  * const NameModel = mongoose.model("Name", NameSchema);
  * ```
  */
-export function buildSchema<U extends AnyParamConstructor<any>>(cl: U, options?: mongoose.SchemaOptions): mongoose.Schema<U> {
+export function buildSchema<U extends AnyParamConstructor<any>>(cl: U, options?: mongoose.SchemaOptions): mongoose.Schema<DocumentType<U>> {
   assertionIsClass(cl);
 
   logger.debug('buildSchema called for "%s"', getName(cl));
 
   const mergedOptions = mergeSchemaOptions(options, cl);
 
-  let sch: mongoose.Schema<U> | undefined = undefined;
+  let sch: mongoose.Schema<DocumentType<U>> | undefined = undefined;
   /** Parent Constructor */
   let parentCtor = Object.getPrototypeOf(cl.prototype).constructor;
   // iterate trough all parents
@@ -254,7 +254,7 @@ export function getDiscriminatorModelForClass<U extends AnyParamConstructor<any>
     return models.get(name) as ReturnModelType<U, QueryHelpers>;
   }
 
-  const sch = buildSchema(cl) as mongoose.Schema & { paths: any };
+  const sch: mongoose.Schema<any> = buildSchema(cl);
 
   const discriminatorKey = sch.get('discriminatorKey');
 

--- a/src/typeguards.ts
+++ b/src/typeguards.ts
@@ -6,7 +6,7 @@ import type { DocumentType, Ref, RefType } from './types';
  * Check if the given document is already populated
  * @param doc The Ref with uncertain type
  */
-export function isDocument<T, S extends RefType>(doc: Ref<T, S>): doc is DocumentType<NonNullable<T>> {
+export function isDocument<T, S extends RefType>(doc: Ref<T, S>): doc is DocumentType<T> {
   return doc instanceof mongoose.Model;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,6 @@ import type { Severity, WhatIsIt } from './internal/constants';
  */
 export type DocumentType<T> = (T extends { _id: unknown } ? mongoose.Document<T['_id']> & T : mongoose.Document & T) &
   IObjectWithTypegooseFunction;
-// I tested "T & (T extends ? : )" already, but it didnt work out
 /**
  * Used Internally for ModelTypes
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,8 +17,7 @@ export type DocumentType<T> = (T extends { _id: unknown } ? mongoose.Document<T[
 /**
  * Used Internally for ModelTypes
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type ModelType<T, _QueryHelpers = BeAnObject> = mongoose.Model<DocumentType<T> /* , QueryHelpers */>;
+export type ModelType<T, QueryHelpers = BeAnObject> = mongoose.Model<DocumentType<T>, QueryHelpers>;
 /**
  * Any-param Constructor
  */

--- a/test/tests/arrayValidator.test.ts
+++ b/test/tests/arrayValidator.test.ts
@@ -66,7 +66,6 @@ it('should respect enum [String]', async () => {
   try {
     await ArrayValidatorsModel.create({
       enumedString: [
-        // @ts-expect-error because value is not in enum
         'not in the enum', // string not in the enum
       ],
     });

--- a/test/tests/biguser.test.ts
+++ b/test/tests/biguser.test.ts
@@ -1,8 +1,7 @@
 import * as mongoose from 'mongoose';
 import { assertion, isNullOrUndefined } from '../../src/internal/utils';
-import { DocumentType } from '../../src/types';
 import { CarModel } from '../models/car';
-import { Genders, Role, User, UserModel } from '../models/user';
+import { Genders, Role, UserModel } from '../models/user';
 
 it(
   'should create a User with connections',
@@ -23,7 +22,7 @@ it(
       },
     ]);
 
-    const user = await UserModel.create<DocumentType<Omit<User, 'fullName'>>>({
+    const user = await UserModel.create({
       _id: mongoose.Types.ObjectId(),
       firstName: 'John',
       lastName: 'Doe',
@@ -137,7 +136,7 @@ it('should create a user with [Plugin].findOrCreate', async () => {
   expect(foundUser.doc).toHaveProperty('firstName', 'Jane');
 
   try {
-    await UserModel.create<DocumentType<Omit<User, 'fullName'>>>({
+    await UserModel.create({
       _id: mongoose.Types.ObjectId(),
       firstName: 'John',
       lastName: 'Doe',

--- a/test/tests/discriminators.test.ts
+++ b/test/tests/discriminators.test.ts
@@ -1,3 +1,4 @@
+import { LeanDocument } from 'mongoose';
 import { assertion } from '../../src/internal/utils';
 import {
   DocumentType,
@@ -169,7 +170,7 @@ it('should pass all mongoose discriminator tests', async () => {
 
   // https://mongoosejs.com/docs/discriminators.html#using-discriminators-with-model-create
   const events = await Promise.all([
-    EventModel.create<DocumentType<ClickedLinkEvent>>({ time: Date.now(), url: 'google.com' }),
+    EventModel.create<LeanDocument<ClickedLinkEvent>>({ time: new Date(Date.now()), url: 'google.com' }),
     ClickedLinkEventModel.create({ time: Date.now(), url: 'google.com' }),
     SignedUpEventModel.create({ time: Date.now(), user: 'testuser' }),
   ]);

--- a/test/tests/getClassForDocument.test.ts
+++ b/test/tests/getClassForDocument.test.ts
@@ -1,5 +1,5 @@
 import * as mongoose from 'mongoose';
-import { DocumentType, getClassForDocument, isDocument } from '../../src/typegoose';
+import { getClassForDocument, isDocument } from '../../src/typegoose';
 import { Car, CarModel } from '../models/car';
 import { InternetUserModel } from '../models/internetUser';
 import { AddressNested, AddressNestedModel, PersonNested, PersonNestedModel } from '../models/nestedObject';
@@ -14,7 +14,7 @@ it('should return correct class type for document', async () => {
   const carReflectedType = getClassForDocument(car);
   expect(carReflectedType).toEqual(Car);
 
-  const user = await UserModel.create<DocumentType<Omit<User, 'fullName'>>>({
+  const user = await UserModel.create({
     firstName: 'John2',
     lastName: 'Doe2',
     gender: Genders.MALE,
@@ -122,7 +122,6 @@ it('should validate email', async () => {
 it(`should Validate Map`, async () => {
   try {
     await InternetUserModel.create({
-      // @ts-expect-error because value dosnt exsit in "ProjectValue"
       projects: {
         p1: 'project',
       },

--- a/test/tests/shouldAdd.test.ts
+++ b/test/tests/shouldAdd.test.ts
@@ -19,11 +19,11 @@ import { InternetUserModel } from '../models/internetUser';
 import { Beverage, BeverageModel, InventoryModel, ScooterModel } from '../models/inventory';
 import { Job } from '../models/job';
 import { OptionsClass, OptionsModel } from '../models/options';
-import { Genders, User, UserModel } from '../models/user';
+import { Genders, UserModel } from '../models/user';
 import { NonVirtual, NonVirtualGS, NonVirtualGSModel, NonVirtualModel, VirtualModel, VirtualSubModel } from '../models/virtualprop';
 
 it('should add a language and job using instance methods', async () => {
-  const user = await UserModel.create<DocumentType<Omit<User, 'fullName'>>>({
+  const user = await UserModel.create({
     firstName: 'harry',
     lastName: 'potter',
     gender: Genders.MALE,

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -404,7 +404,6 @@ it('should add query Methods', async () => {
 
   const doc = await QueryMethodsModel.create({ name: 'hello', lastname: 'world' });
 
-  // @ts-expect-error Currently the mongoose types dosnt have QueryMethods
   const found = await QueryMethodsModel.find().findByName('hello').findByLastname('world').orFail().exec();
   assertion(isDocumentArray(found), new Error('Found is not an document array'));
   expect(found[0].toObject()).toEqual(doc.toObject());

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -263,6 +263,7 @@ it('should run with Custom Types', async () => {
       super(key, options, 'CustomInt');
     }
 
+    // @ts-expect-error mongoose types have wrong types for this
     public cast(val) {
       return Number(val);
     }
@@ -403,6 +404,7 @@ it('should add query Methods', async () => {
 
   const doc = await QueryMethodsModel.create({ name: 'hello', lastname: 'world' });
 
+  // @ts-expect-error Currently the mongoose types dosnt have QueryMethods
   const found = await QueryMethodsModel.find().findByName('hello').findByLastname('world').orFail().exec();
   assertion(isDocumentArray(found), new Error('Found is not an document array'));
   expect(found[0].toObject()).toEqual(doc.toObject());

--- a/test/tests/stringValidator.test.ts
+++ b/test/tests/stringValidator.test.ts
@@ -45,7 +45,6 @@ it('should lowercase', async () => {
 it('should respect enum', async () => {
   try {
     await StringValidatorsModel.create({
-      // @ts-expect-error expect error because "string" is not in the enum
       enumed: 'not in the enum', // string not in the enum
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -985,20 +985,12 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
-"@types/mongodb@*":
+"@types/mongodb@^3.5.27":
   version "3.6.8"
   resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.6.8.tgz#f80f0a3022c44d8db659a936434403ca3f4661df"
   integrity sha512-8qNbL5/GFrljXc/QijcuQcUMYZ1iWNcqnJ6tneROwbfU0LsAjQ9bmq3aHi5lWXM4cyBPd2F/n9INAk/pZZttHw==
   dependencies:
     "@types/bson" "*"
-    "@types/node" "*"
-
-"@types/mongoose@^5.10.2":
-  version "5.10.3"
-  resolved "https://registry.yarnpkg.com/@types/mongoose/-/mongoose-5.10.3.tgz#3bc6787245aa8ebbff4ed61da18f4775e0ec52cd"
-  integrity sha512-VfdnaFImXEJZZiuL2ID/ysZs4inOIjxwrAnUgkr5eum2O2BLhFkiSI0i87AwignVva1qWTJ3H3DyM0Rf4USJ4A==
-  dependencies:
-    "@types/mongodb" "*"
     "@types/node" "*"
 
 "@types/node@*":
@@ -4642,10 +4634,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-kareem@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.3.1.tgz#def12d9c941017fabfb00f873af95e9c99e1be87"
-  integrity sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw==
+kareem@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.3.2.tgz#78c4508894985b8d38a0dc15e1a8e11078f2ca93"
+  integrity sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -5410,10 +5402,10 @@ mongodb@3.6.2:
   optionalDependencies:
     saslprep "^1.0.0"
 
-mongodb@3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.6.3.tgz#eddaed0cc3598474d7a15f0f2a5b04848489fd05"
-  integrity sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==
+mongodb@3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.6.4.tgz#ca59fd65b06831308262372ef9df6b78f9da97be"
+  integrity sha512-Y+Ki9iXE9jI+n9bVtbTOOdK0B95d6wVGSucwtBkvQ+HIvVdTCfpVRp01FDC24uhC/Q2WXQ8Lpq3/zwtB5Op9Qw==
   dependencies:
     bl "^2.2.1"
     bson "^1.1.4"
@@ -5433,17 +5425,18 @@ mongoose-legacy-pluralize@1.0.2:
   resolved "https://registry.yarnpkg.com/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz#3ba9f91fa507b5186d399fb40854bff18fb563e4"
   integrity sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==
 
-"mongoose@5.10.0 - 5.10.18":
-  version "5.10.18"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.10.18.tgz#ec99a8bc524bd0fd2a82b5afd6f1f720f462c45f"
-  integrity sha512-vaLUzBpUxqacoCqP/xXWMg/uVwCDrlc8LvYjDXCf8hdApvX/CXa0HLa7v2ieFaVd5Fgv3W2QXODLoC4Z/abbNw==
+mongoose@^5.11.19:
+  version "5.11.19"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.11.19.tgz#fb20ee6145f4ca9bd757f87ed3ae9e13e92effde"
+  integrity sha512-+oMf4XVg+j7ygnALi7K5vWZfKvC9gs9jdN/6Y1GV5OUAc7KQWoa6hzFO7nSj5jMJlhHNvC6tcS2uU7BV5aH8Lg==
   dependencies:
+    "@types/mongodb" "^3.5.27"
     bson "^1.1.4"
-    kareem "2.3.1"
-    mongodb "3.6.3"
+    kareem "2.3.2"
+    mongodb "3.6.4"
     mongoose-legacy-pluralize "1.0.2"
-    mpath "0.7.0"
-    mquery "3.2.2"
+    mpath "0.8.3"
+    mquery "3.2.4"
     ms "2.1.2"
     regexp-clone "1.0.0"
     safe-buffer "5.2.1"
@@ -5462,15 +5455,15 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
-mpath@0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.7.0.tgz#20e8102e276b71709d6e07e9f8d4d0f641afbfb8"
-  integrity sha512-Aiq04hILxhz1L+f7sjGyn7IxYzWm1zLNNXcfhDtx04kZ2Gk7uvFdgZ8ts1cWa/6d0TQmag2yR8zSGZUmp0tFNg==
+mpath@0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.8.3.tgz#828ac0d187f7f42674839d74921970979abbdd8f"
+  integrity sha512-eb9rRvhDltXVNL6Fxd2zM9D4vKBxjVVQNLNijlj7uoXUy19zNDsIif5zR+pWmPCWNKwAtqyo4JveQm4nfD5+eA==
 
-mquery@3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/mquery/-/mquery-3.2.2.tgz#e1383a3951852ce23e37f619a9b350f1fb3664e7"
-  integrity sha512-XB52992COp0KP230I3qloVUbkLUxJIu328HBP2t2EsxSFtf4W1HPSOBWOXf1bqxK4Xbb66lfMJ+Bpfd9/yZE1Q==
+mquery@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/mquery/-/mquery-3.2.4.tgz#9c5c2e285ea6c6f20673f3528973c99ee1aaa1a0"
+  integrity sha512-uOLpp7iRX0BV1Uu6YpsqJ5b42LwYnmu0WeF/f8qgD/On3g0XDaQM6pfn0m6UxO6SM8DioZ9Bk6xxbWIGHm2zHg==
   dependencies:
     bluebird "3.5.1"
     debug "3.1.0"


### PR DESCRIPTION
Change Typegoose to be compatible with mongoose 5.11+

Before Merging, some things need to happen before:
- mongoose version 5.11.19 being released, which included official QueryMethods
- https://github.com/Automattic/mongoose/issues/9980 as an sidenote
- this change needs to be tested

## Related Issues

- fixes #432