### PR TITLE
feat(getModelForClass): use customName and automaticName from options (#495)

### DIFF
--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -32,7 +32,8 @@ export function _buildSchema<U extends AnyParamConstructor<any>>(
   cl: U,
   sch?: mongoose.Schema,
   opt?: mongoose.SchemaOptions,
-  isFinalSchema: boolean = true
+  isFinalSchema: boolean = true,
+  overwriteOptions?: IModelOptions
 ) {
   assertionIsClass(cl);
 
@@ -41,9 +42,11 @@ export function _buildSchema<U extends AnyParamConstructor<any>>(
   // Options sanity check
   opt = mergeSchemaOptions(isNullOrUndefined(opt) || typeof opt !== 'object' ? {} : opt, cl);
 
-  const name = getName(cl);
+  /** used, because when trying to resolve an child, the overwriteOptions for that child are not available */
+  const className = getName(cl);
+  const finalName = getName(cl, overwriteOptions);
 
-  logger.debug('_buildSchema Called for %s with options:', name, opt);
+  logger.debug('_buildSchema Called for %s with options:', finalName, opt);
 
   /** Simplify the usage */
   const Schema = mongoose.Schema;
@@ -58,15 +61,15 @@ export function _buildSchema<U extends AnyParamConstructor<any>>(
     }
   }
 
-  if (!schemas.has(name)) {
-    schemas.set(name, {});
+  if (!schemas.has(className)) {
+    schemas.set(className, {});
   }
 
   if (!(sch instanceof Schema)) {
-    sch = new Schema(schemas.get(name), schemaOptions);
+    sch = new Schema(schemas.get(className), schemaOptions);
   } else {
     sch = sch.clone();
-    sch.add(schemas.get(name)!);
+    sch.add(schemas.get(className)!);
   }
 
   sch.loadClass(cl);
@@ -80,14 +83,14 @@ export function _buildSchema<U extends AnyParamConstructor<any>>(
         logger.debug('Applying Nested Discriminators for:', key, discriminators);
 
         const path: { discriminator?: Func } = sch.path(key) as any;
-        assertion(!isNullOrUndefined(path), new Error(`Path "${key}" does not exist on Schema of "${name}"`));
+        assertion(!isNullOrUndefined(path), new Error(`Path "${key}" does not exist on Schema of "${finalName}"`));
         assertion(
           typeof path.discriminator === 'function',
-          new Error(`There is no function called "discriminator" on schema-path "${key}" on Schema of "${name}"`)
+          new Error(`There is no function called "discriminator" on schema-path "${key}" on Schema of "${finalName}"`)
         );
 
         for (const { type: child, value: childName } of discriminators) {
-          const childSch = getName(child) === name ? sch : (buildSchema(child) as mongoose.Schema & { paths: any });
+          const childSch = getName(child) === finalName ? sch : (buildSchema(child) as mongoose.Schema & { paths: any });
 
           const discriminatorKey = childSch.get('discriminatorKey');
 
@@ -159,12 +162,12 @@ export function _buildSchema<U extends AnyParamConstructor<any>>(
 
     // this method is to get the typegoose name of the model/class if it is user-handled (like buildSchema, then manually mongoose.model)
     sch.method('typegooseName', () => {
-      return name;
+      return finalName;
     });
   }
 
   // add the class to the constructors map
-  constructors.set(name, cl);
+  constructors.set(finalName, cl);
 
   return sch;
 }

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -309,11 +309,11 @@ export function getRightTarget(target: any): any {
  * (with suffix)
  * @param cl The Class
  */
-export function getName<U extends AnyParamConstructor<any>>(cl: U) {
+export function getName<U extends AnyParamConstructor<any>>(cl: U, customOptions?: IModelOptions) {
   const ctor: any = getRightTarget(cl);
   const options: IModelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, ctor) ?? {};
   const baseName: string = ctor.name;
-  const customName = options.options?.customName;
+  const customName = customOptions?.options?.customName ?? options.options?.customName;
 
   if (typeof customName === 'function') {
     const name: any = customName(options);
@@ -328,8 +328,10 @@ export function getName<U extends AnyParamConstructor<any>>(cl: U) {
     return name;
   }
 
-  if (options.options?.automaticName) {
-    const suffix = customName ?? options.schemaOptions?.collection;
+  const automaticName = customOptions?.options?.automaticName ?? options.options?.automaticName;
+
+  if (automaticName) {
+    const suffix = customName ?? customOptions?.schemaOptions?.collection ?? options.schemaOptions?.collection;
 
     return !isNullOrUndefined(suffix) ? `${baseName}_${suffix}` : baseName;
   }

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -308,6 +308,7 @@ export function getRightTarget(target: any): any {
  * Get the correct name of the class's model
  * (with suffix)
  * @param cl The Class
+ * @param customOptions Extra Options that can be added in "buildSchema"
  */
 export function getName<U extends AnyParamConstructor<any>>(cl: U, customOptions?: IModelOptions) {
   const ctor: any = getRightTarget(cl);

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -89,7 +89,6 @@ export function getModelForClass<U extends AnyParamConstructor<any>, QueryHelper
   }
 
   return addModelToTypegoose<U, QueryHelpers>(compiledmodel, cl, {
-    name,
     existingMongoose: roptions?.existingMongoose,
     existingConnection: roptions?.existingConnection,
   });
@@ -163,14 +162,14 @@ export function buildSchema<U extends AnyParamConstructor<any>>(cl: U, options?:
 export function addModelToTypegoose<U extends AnyParamConstructor<any>, QueryHelpers = BeAnObject>(
   model: mongoose.Model<any>,
   cl: U,
-  options?: { name?: string; existingMongoose?: mongoose.Mongoose; existingConnection?: any }
+  options?: { existingMongoose?: mongoose.Mongoose; existingConnection?: any }
 ) {
   const mongooseModel = options?.existingMongoose?.Model || options?.existingConnection?.base?.Model || mongoose.Model;
 
   assertion(model.prototype instanceof mongooseModel, new TypeError(`"${model}" is not a valid Model!`));
   assertionIsClass(cl);
 
-  const name = options?.name ?? getName(cl);
+  const name = model.modelName;
 
   assertion(
     !models.has(name),

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -217,7 +217,6 @@ export function deleteModel(name: string) {
 /**
  * Delete a model, with the given class
  * Same as "deleteModel", only that it can be done with the class instead of the name
- * Does not work when you set `options.customName` on getModelForClass
  * @param cl The Class
  * @example
  * ```ts
@@ -229,7 +228,28 @@ export function deleteModel(name: string) {
 export function deleteModelWithClass<U extends AnyParamConstructor<any>>(cl: U) {
   assertionIsClass(cl);
 
-  return deleteModel(getName(cl));
+  let name = getName(cl);
+
+  if (!models.has(name)) {
+    logger.debug(`Class "${name}" is not in "models", trying to find in "constructors"`);
+    let found = false;
+
+    for (const [cname, constructor] of constructors) {
+      if (constructor === cl) {
+        logger.debug(`Found Class in "constructors" with class name "${name}" and entered name "${cname}""`);
+        name = cname;
+        found = true;
+      }
+    }
+
+    if (!found) {
+      logger.debug(`Could not find class "${name}" in constructors`);
+
+      return;
+    }
+  }
+
+  return deleteModel(name);
 }
 
 /**

--- a/test/tests/customName.test.ts
+++ b/test/tests/customName.test.ts
@@ -180,3 +180,43 @@ it('should not make an automatic name if no collection or customName are defined
   const model = getModelForClass(NoAutomaticName);
   expect(model.modelName).toEqual('NoAutomaticName');
 });
+
+it('should use customName from getModelForClass', () => {
+  class CustomNameGetModelForClass {
+    @prop()
+    public test: string;
+  }
+
+  const model = getModelForClass(CustomNameGetModelForClass, { options: { customName: 'CustomName' }});
+  expect(model.modelName).toEqual('CustomName');
+});
+
+it('should use customName from getModelForClass over the one defined via modelOptions', () => {
+  @modelOptions({
+    options: {
+      customName: 'WrongName',
+    },
+  })
+  class CustomNameGetModelForClassOverModelOptions {
+    @prop()
+    public test: string;
+  }
+
+  const model = getModelForClass(CustomNameGetModelForClassOverModelOptions, { options: { customName: 'RightName' }});
+  expect(model.modelName).toEqual('RightName');
+});
+
+it('should use customName provided via getModelForClass with automaticName from modelOptions', () => {
+  @modelOptions({ options: { automaticName: true } })
+  class CustomNameOption {}
+
+  const model = getModelForClass(CustomNameOption, { options: { customName: 'CustomName' }});
+  expect(model.modelName).toEqual('CustomNameOption_CustomName');
+});
+
+it('should use customName and automaticName provided via getModelForClass', () => {
+  class CustomNameOption {}
+
+  const model = getModelForClass(CustomNameOption, { options: { customName: 'CustomName', automaticName: true }});
+  expect(model.modelName).toEqual('CustomNameOption_CustomName');
+});

--- a/test/tests/customName.test.ts
+++ b/test/tests/customName.test.ts
@@ -1,4 +1,4 @@
-import { getClassForDocument, getModelForClass, modelOptions, prop } from '../../src/typegoose';
+import { getClass, getClassForDocument, getModelForClass, modelOptions, prop } from '../../src/typegoose';
 
 it('expect no changes to model Name when not using customOptions or collection', () => {
   class NormalOptions {}
@@ -187,7 +187,7 @@ it('should use customName from getModelForClass', () => {
     public test: string;
   }
 
-  const model = getModelForClass(CustomNameGetModelForClass, { options: { customName: 'CustomName' }});
+  const model = getModelForClass(CustomNameGetModelForClass, { options: { customName: 'CustomName' } });
   expect(model.modelName).toEqual('CustomName');
 });
 
@@ -202,7 +202,7 @@ it('should use customName from getModelForClass over the one defined via modelOp
     public test: string;
   }
 
-  const model = getModelForClass(CustomNameGetModelForClassOverModelOptions, { options: { customName: 'RightName' }});
+  const model = getModelForClass(CustomNameGetModelForClassOverModelOptions, { options: { customName: 'RightName' } });
   expect(model.modelName).toEqual('RightName');
 });
 
@@ -210,13 +210,33 @@ it('should use customName provided via getModelForClass with automaticName from 
   @modelOptions({ options: { automaticName: true } })
   class CustomNameOption {}
 
-  const model = getModelForClass(CustomNameOption, { options: { customName: 'CustomName' }});
+  const model = getModelForClass(CustomNameOption, { options: { customName: 'CustomName' } });
   expect(model.modelName).toEqual('CustomNameOption_CustomName');
 });
 
 it('should use customName and automaticName provided via getModelForClass', () => {
   class CustomNameOption {}
 
-  const model = getModelForClass(CustomNameOption, { options: { customName: 'CustomName', automaticName: true }});
+  const model = getModelForClass(CustomNameOption, { options: { customName: 'CustomName', automaticName: true } });
   expect(model.modelName).toEqual('CustomNameOption_CustomName');
+});
+
+it('should use customName provided via getModelForClass and work with getClass', () => {
+  class WithGetClass {}
+
+  const model = getModelForClass(WithGetClass, { options: { customName: 'CustomNameWithGetClass', automaticName: false } });
+  expect(model.modelName).toEqual('CustomNameWithGetClass');
+
+  const retrievedClass = getClass('CustomNameWithGetClass');
+  expect(retrievedClass).toBe(WithGetClass);
+});
+
+it('should use customName provided via getModelForClass and work with getClass', () => {
+  class WithAutomaticNameAndGetClass {}
+
+  const model = getModelForClass(WithAutomaticNameAndGetClass, { options: { customName: 'CustomName', automaticName: true } });
+  expect(model.modelName).toEqual('WithAutomaticNameAndGetClass_CustomName');
+
+  const retrievedClass = getClass('WithAutomaticNameAndGetClass_CustomName');
+  expect(retrievedClass).toBe(WithAutomaticNameAndGetClass);
 });

--- a/test/tests/customName.test.ts
+++ b/test/tests/customName.test.ts
@@ -1,3 +1,4 @@
+import { constructors, models, schemas } from '../../src/internal/data';
 import { getClass, getClassForDocument, getModelForClass, modelOptions, prop } from '../../src/typegoose';
 
 it('expect no changes to model Name when not using customOptions or collection', () => {
@@ -189,6 +190,11 @@ it('should use customName from getModelForClass', () => {
 
   const model = getModelForClass(CustomNameGetModelForClass, { options: { customName: 'CustomName' } });
   expect(model.modelName).toEqual('CustomName');
+  const doc = new model();
+  expect(doc.typegooseName()).toEqual('CustomName');
+  expect(schemas.get(model.modelName)).toBeUndefined();
+  expect(constructors.get(model.modelName)).toBeDefined();
+  expect(models.get(model.modelName)).toEqual(model);
 });
 
 it('should use customName from getModelForClass over the one defined via modelOptions', () => {
@@ -204,21 +210,36 @@ it('should use customName from getModelForClass over the one defined via modelOp
 
   const model = getModelForClass(CustomNameGetModelForClassOverModelOptions, { options: { customName: 'RightName' } });
   expect(model.modelName).toEqual('RightName');
+  const doc = new model();
+  expect(doc.typegooseName()).toEqual('RightName');
+  expect(schemas.get(model.modelName)).toBeUndefined();
+  expect(constructors.get(model.modelName)).toBeDefined();
+  expect(models.get(model.modelName)).toEqual(model);
 });
 
 it('should use customName provided via getModelForClass with automaticName from modelOptions', () => {
   @modelOptions({ options: { automaticName: true } })
   class CustomNameOption {}
 
-  const model = getModelForClass(CustomNameOption, { options: { customName: 'CustomName' } });
-  expect(model.modelName).toEqual('CustomNameOption_CustomName');
+  const model = getModelForClass(CustomNameOption, { options: { customName: 'CustomName1' } });
+  expect(model.modelName).toEqual('CustomNameOption_CustomName1');
+  const doc = new model();
+  expect(doc.typegooseName()).toEqual('CustomNameOption_CustomName1');
+  expect(schemas.get(model.modelName)).toBeUndefined();
+  expect(constructors.get(model.modelName)).toBeDefined();
+  expect(models.get(model.modelName)).toEqual(model);
 });
 
 it('should use customName and automaticName provided via getModelForClass', () => {
   class CustomNameOption {}
 
-  const model = getModelForClass(CustomNameOption, { options: { customName: 'CustomName', automaticName: true } });
-  expect(model.modelName).toEqual('CustomNameOption_CustomName');
+  const model = getModelForClass(CustomNameOption, { options: { customName: 'CustomName2', automaticName: true } });
+  expect(model.modelName).toEqual('CustomNameOption_CustomName2');
+  const doc = new model();
+  expect(doc.typegooseName()).toEqual('CustomNameOption_CustomName2');
+  expect(schemas.get(model.modelName)).toBeUndefined();
+  expect(constructors.get(model.modelName)).toBeDefined();
+  expect(models.get(model.modelName)).toEqual(model);
 });
 
 it('should use customName provided via getModelForClass and work with getClass', () => {

--- a/test/tests/overwrittenModel.test.ts
+++ b/test/tests/overwrittenModel.test.ts
@@ -80,3 +80,17 @@ it('should delete model from different connection', async () => {
 
   await connection.close();
 });
+
+it('should delete model with class when normal name is not found in "models"', () => {
+  class CustomNameOnFunctionCall {
+    @prop()
+    public test: string;
+  }
+
+  const model = getModelForClass(CustomNameOnFunctionCall, { options: { customName: 'CustomNameFC' } });
+  expect(model.modelName).toEqual('CustomNameFC');
+  expect(models.has(model.modelName)).toBeTruthy();
+
+  deleteModelWithClass(CustomNameOnFunctionCall);
+  expect(models.has(model.modelName)).toBeFalsy();
+});


### PR DESCRIPTION
This PR adds an customOptions optional field to `getName`. The function will priorize `options.customName`, `options.automaticName` and `schemaOptions.collection` provided in `customOptions` over the ones extracted via Reflection.

With this, `getModelForClass` can send the options it receveid to `getName`, fixing the issue where those fields, when provided via options to `getModelForClass` were not taken into account.

## Related Issues

fixes #495 