### PR TITLE
docs(array-types) - added array types page

### DIFF
--- a/docs/guides/advanced/array-types.md
+++ b/docs/guides/advanced/array-types.md
@@ -3,6 +3,8 @@ id: array-types
 title: 'Array Types & Fields'
 ---
 
+## Array types & Fields
+
 It is much easier to declare the array field's type as `type[]` instead of `Array<type>`.
 
 But in some cases, Typescript could give you a warning, when you would like to use [any mongoose array methods](https://mongoosejs.com/docs/api/array.html) on the array field.

--- a/docs/guides/advanced/array-types.md
+++ b/docs/guides/advanced/array-types.md
@@ -20,6 +20,6 @@ class Model {
 
 ## Why does it could happen?
 
-Mainly, because mongoose documents and their arrays fields have their pre-build methods, which slightly differ from `Array.method.prototype`. But at runtime, these methods already exist (because an array is always an mongoose array). So, using of `type[]` is just more convenient way to write the shorter type instead of the `mongoose.Types` if the functions are not used. 
+Mainly, because mongoose documents and their arrays fields have their pre-build methods, which slightly differ from `Array.method.prototype`. But at runtime, these methods already exist (because an array is always an mongoose array). So, using `type[]` is just more convenient way to write a shorter type instead of the `mongoose.Types` if the functions are not used. 
 
 For more information you could look at the following [GitHub issue page](https://github.com/typegoose/typegoose/issues/509).

--- a/docs/guides/advanced/array-types.md
+++ b/docs/guides/advanced/array-types.md
@@ -11,7 +11,7 @@ To avoid such behavior, you could always declare the array field via `mongoose.T
 Example:
 
 ```ts
-class Model {
+class ModelClass {
   //required field, with emplty array by default.
   @prop({ required: true, default: [] })
   public field!: mongoose.Types.Array<string>;

--- a/docs/guides/advanced/array-types.md
+++ b/docs/guides/advanced/array-types.md
@@ -8,7 +8,7 @@ It is much easier to declare the array field's type as `type[]` instead of `Arra
 But in some cases, Typescript could give you a warning, when you would like to use [any mongoose array methods](https://mongoosejs.com/docs/api/array.html) on the array field.
 To avoid such behavior, you could always declare the array field via `mongoose.Types.Array<type>` or `mongoose.Schema.Types.Array<type>`
 
-Example with `Class`:
+Example:
 
 ```ts
 class Model {

--- a/docs/guides/advanced/array-types.md
+++ b/docs/guides/advanced/array-types.md
@@ -12,7 +12,7 @@ Example:
 
 ```ts
 class ModelClass {
-  //required field, with emplty array by default.
+  // required field, with empty array by default.
   @prop({ required: true, default: [] })
   public field!: mongoose.Types.Array<string>;
 }

--- a/docs/guides/advanced/array-types.md
+++ b/docs/guides/advanced/array-types.md
@@ -22,4 +22,4 @@ class ModelClass {
 
 Mainly, because mongoose documents and their arrays fields have their pre-build methods, which slightly differ from `Array.method.prototype`. But at runtime, these methods already exist (because an array is always an mongoose array). So, using `type[]` is just more convenient way to write a shorter type instead of the `mongoose.Types` if the functions are not used. 
 
-For more information you could look at the following [GitHub issue page](https://github.com/typegoose/typegoose/issues/509).
+For more information you could look at [GitHub issue #509](https://github.com/typegoose/typegoose/issues/509).

--- a/docs/guides/advanced/array-types.md
+++ b/docs/guides/advanced/array-types.md
@@ -1,0 +1,25 @@
+---
+id: array-types
+title: 'Array Types & Fields'
+---
+
+It is much easier to declare the array field's type as `type[]` instead of `Array<type>`.
+
+But in some cases, Typescript could give you a warning, when you would like to use [any mongoose array methods](https://mongoosejs.com/docs/api/array.html) on the array field.
+To avoid such behavior, you could always declare the array field via `mongoose.Types.Array<type>` or `mongoose.Schema.Types.Array<type>`
+
+Example with `Class`:
+
+```ts
+class Model {
+  //required field, with emplty array by default.
+  @prop({ required: true, default: [] })
+  public field!: mongoose.Types.Array<string>;
+}
+```
+
+## Why does it could happen?
+
+Mainly, because mongoose documents and their arrays fields have their pre-build methods, which slightly differ from `Array.method.prototype`. But at runtime, these methods already exist (because an array is always an mongoose array). So, using of `type[]` is just more convenient way to write the shorter type instead of the `mongoose.Types` if the functions are not used. 
+
+For more information you could look at the following [GitHub issue page](https://github.com/typegoose/typegoose/issues/509).

--- a/docs/guides/advanced/array-types.md
+++ b/docs/guides/advanced/array-types.md
@@ -18,7 +18,7 @@ class ModelClass {
 }
 ```
 
-## Why does it could happen?
+## Why is the long type needed?
 
 Mainly, because mongoose documents and their arrays fields have their pre-build methods, which slightly differ from `Array.method.prototype`. But at runtime, these methods already exist (because an array is always an mongoose array). So, using `type[]` is just more convenient way to write a shorter type instead of the `mongoose.Types` if the functions are not used. 
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -9,7 +9,7 @@ module.exports = {
   guides: {
     "Getting Started": ["guides/quick-start-guide", "guides/faq", "guides/known-issues", "guides/deprecation-codes", "guides/error-warnings-details"],
     Basics: ["guides/all-decorators", "guides/motivation", "guides/default-classes", "guides/use-without-emitDecoratorMetadata"],
-    Advanced: ["guides/advanced/custom-types", "guides/advanced/models-with-same-name", "guides/advanced/logger", "guides/advanced/reference-other-classes", "guides/advanced/common-plugins", "guides/advanced/change-id-type", "guides/advanced/using-objectid-type", "guides/advanced/using-with-class-transformer"],
+    Advanced: ["guides/advanced/custom-types", "guides/advanced/array-types", "guides/advanced/models-with-same-name", "guides/advanced/logger", "guides/advanced/reference-other-classes", "guides/advanced/common-plugins", "guides/advanced/change-id-type", "guides/advanced/using-objectid-type", "guides/advanced/using-with-class-transformer"],
     Migration: ["guides/migrate-6", "guides/migrate-7"]
   }
 };


### PR DESCRIPTION
## Adds Documentation for
 - array types

I have added a page to the `Advanced` part of the documentation, which covers the case in the #509 issue.  If the whole page is too much, I am ready to extend information in any other of the existing doc pages. But I thought, that having a separate page in the `Advanced` area of the site, Is much better because it could be useful to have it in the future and add other information, that could be relative to the array fields.

I hope that PR has been made correctly and will be approved by @hasezoey

<!--
Try to use a template, found at .github/PULL_REQUEST_TEMPLATE/
[here](https://github.com/typegoose/typegoose/tree/master/.github/PULL_REQUEST_TEMPLATE)
please don't forget to click on raw, and copy that, not the already "compiled" one
-->

<!--
## Make sure you have done these steps

- Make sure you have Read & followed these steps in [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

<!--Write your PR description here (above "Related Issues")-->

## Related Issues

<!--add "fixes" / "closes" before an number to indicate that these will be fixed by this pr-->

- #509 
