### PR TITLE
fix mongoose collections assertion in [docs]

### DIFF
--- a/docs/guides/advanced/models-with-same-name.md
+++ b/docs/guides/advanced/models-with-same-name.md
@@ -27,7 +27,7 @@ Example without `automaticName`:
 class MultiModel {}
 
 const model = getModelForClass(MultiModel);
-expect(model.modelName).to.be.equal('MultiModel');
+expect(model.modelName).to.be.equal('Something');
 ```
 
 Example with `automaticName`:


### PR DESCRIPTION
In the documentation the `@modelOptions({ schemaOptions: { collection: 'Something' } })` assertion is misleading as the outcome when using the option generates a different output `Something`

<!--
Try to use a template, found at .github/PULL_REQUEST_TEMPLATE/
[here](https://github.com/typegoose/typegoose/tree/master/.github/PULL_REQUEST_TEMPLATE)
please don't forget to click on raw, and copy that, not the already "compiled" one
-->

<!--
## Make sure you have done these steps

- Make sure you have Read & followed these steps in [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

<!--Write your PR description here (above "Related Issues")-->
