### PR TITLE
add convenience typing of index decorator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,10 @@ import type { BeAnObject, IIndexArray, IndexOptions } from './types';
  * class ClassName {}
  * ```
  */
-export function index<T = BeAnObject>(fields: Partial<Record<keyof T, any> & BeAnObject>, options?: IndexOptions<T>): ClassDecorator {
+export function index<T extends BeAnObject = BeAnObject>(
+  fields: Partial<Record<keyof T, string | -1 | 1>>,
+  options?: IndexOptions<T>
+): ClassDecorator {
   return (target: any) => {
     logger.info('Adding "%o" Indexes to %s', { fields, options }, getName(target));
     const indices: IIndexArray<any>[] = Array.from(Reflect.getMetadata(DecoratorKeys.Index, target) ?? []);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import type { BeAnObject, IIndexArray, IndexOptions } from './types';
  * class ClassName {}
  * ```
  */
-export function index<T = BeAnObject>(fields: T, options?: IndexOptions<T>): ClassDecorator {
+export function index<T = BeAnObject>(fields: Partial<Record<keyof T, any> & BeAnObject>, options?: IndexOptions<T>): ClassDecorator {
   return (target: any) => {
     logger.info('Adding "%o" Indexes to %s', { fields, options }, getName(target));
     const indices: IIndexArray<any>[] = Array.from(Reflect.getMetadata(DecoratorKeys.Index, target) ?? []);

--- a/test/models/indexweigths.ts
+++ b/test/models/indexweigths.ts
@@ -1,7 +1,7 @@
 import { getModelForClass, index, prop } from '../../src/typegoose';
 
 // using examples from https://docs.mongodb.com/manual/tutorial/control-results-of-text-search/
-@index(
+@index<IndexWeights>(
   { content: 'text', about: 'text', keywords: 'text' },
   {
     weights: {


### PR DESCRIPTION
### Problem

The `index` decorator does not have enforced typing in its arguments by default.

When tried the following:
```ts
@index<User>({name:1})
class User{
@prop()
name!: string
@prop()
email!:string
}
```

It gave 2 errors:

1. `email` field missing
2. `name` field has to be of type string

which are non-legitimate exceptions.

### Workarounds

```ts
@index<Partial<Records<keyof User,any>>&{[key:string]:any}>({name:1})
// ...
```

### Solution

This PR technically only implements the workaround above inside this lib itself.