### PR TITLE
fix(defaultClasses): add missing 2nd parameter for findOrCreate() +

### DIFF
--- a/src/defaultClasses.ts
+++ b/src/defaultClasses.ts
@@ -29,5 +29,9 @@ export interface FindOrCreateResult<T> {
  * This class contains all types for the module "mongoose-findorcreate"
  */
 export abstract class FindOrCreate {
-  public static findOrCreate: <T extends FindOrCreate>(this: AnyParamConstructor<T>, condition: any) => Promise<FindOrCreateResult<T>>;
+  public static findOrCreate: <T extends FindOrCreate>(
+    this: AnyParamConstructor<T>,
+    condition: any,
+    createWith?: any
+  ) => Promise<FindOrCreateResult<T>>;
 }


### PR DESCRIPTION


Fix TS2554 error when trying to use findOrCreate() with two parameters.

The findOrCreate() implementation takes a second parameter to pass values that are added to the filter values to create a new Document.

[drudge/mongoose-findorcreate#usage](https://github.com/drudge/mongoose-findorcreate#usage)

> You can also include properties that aren't used in the find call, but will be added to the object if it is created.
>```js
>Click.create({ip: '127.0.0.1'}, {browser: 'Mozilla'}, function(err, val) {
>  Click.findOrCreate({ip: '127.0.0.1'}, {browser: 'Chrome'}, function(err, click) {
>   console.log('A click from "%s" using "%s" was found', click.ip, click.browser);
>    // prints A click from "127.0.0.1" using "Mozilla" was found
>  })
>});
>```

Current declaration doesn't reflect that.

---
`Before:`
![tgoose-foc-2554](https://user-images.githubusercontent.com/3411649/124785541-3c2a2880-df47-11eb-8192-85f6eb7912bd.png)

`After:`
![tgoose-foc-2554-fixed](https://user-images.githubusercontent.com/3411649/124785536-3af8fb80-df47-11eb-8544-f30aeda33273.png)