### PR TITLE
chore: lock @types/mongoose version to 5.10 minor in dev and peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@types/mongoose": "^5.10.2",
+    "@types/mongoose": "~5.10.2",
     "mongoose": "5.10.0 - 5.10.18"
   },
   "devDependencies": {
@@ -48,7 +48,7 @@
     "@commitlint/config-conventional": "^12.0.1",
     "@types/jest": "^26.0.20",
     "@types/lodash": "^4.14.161",
-    "@types/mongoose": "^5.10.2",
+    "@types/mongoose": "~5.10.2",
     "@types/node": "^10.17.16",
     "@types/semver": "^7.3.4",
     "@typescript-eslint/eslint-plugin": "^4.15.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,7 +993,7 @@
     "@types/bson" "*"
     "@types/node" "*"
 
-"@types/mongoose@^5.10.2":
+"@types/mongoose@~5.10.2":
   version "5.10.3"
   resolved "https://registry.yarnpkg.com/@types/mongoose/-/mongoose-5.10.3.tgz#3bc6787245aa8ebbff4ed61da18f4775e0ec52cd"
   integrity sha512-VfdnaFImXEJZZiuL2ID/ysZs4inOIjxwrAnUgkr5eum2O2BLhFkiSI0i87AwignVva1qWTJ3H3DyM0Rf4USJ4A==


### PR DESCRIPTION
<!--
Try to use a template, found at .github/PULL_REQUEST_TEMPLATE/
[here](https://github.com/typegoose/typegoose/tree/master/.github/PULL_REQUEST_TEMPLATE)
please don't forget to click on raw, and copy that, not the already "compiled" one
-->

<!--
## Make sure you have done these steps

- Make sure you have Read & followed these steps in [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

<!--Write your PR description here (above "Related Issues")-->
I use typegoose and npm 7 in my project. npm 7 installs peer dependencies by default. Since typegoose has `"@types/mongoose": "^5.10.2"` as a peer dependency, npm installs `"@types/mongoose": "5.11.x"` which in turn doesn't have types anymore. For this reason I changed `^5.10.2` to `~5.10.2`

## Related Issues

<!--add "fixes" / "closes" before an number to indicate that these will be fixed by this pr-->

