### PR TITLE
feat: add class "Passthrough" and functionality

### DIFF
--- a/docs/api/decorators/prop.md
+++ b/docs/api/decorators/prop.md
@@ -770,3 +770,40 @@ enum WhatIsIt {
   NONE // default for properties if no Map / Array is detected
 }
 ```
+
+## Passthrough Class
+
+:::caution
+It is not recommended to use this class, it should always be another class if nesting (and proper validation) like [in the quick-start-guide](../../guides/quick-start-guide.md/#quick-overview-of-typegoose) is wanted
+:::
+
+The `Passthrough` class is, like the name implies, to pass-through an schema definition directly, without "wrapping" it in a `new Schema({}` call.
+
+:::note
+It should be noted that using this method (even in plain mongoose) will result in these paths to become `mongoose.Schema.Types.Mixed`, and also no typegoose transformations or warnings will be applied to what is inside `Passthrough` (like `type: () => Class` will not be translated, it will stay as-is)
+:::
+
+The following example is what it looks like in typegoose, and what it would look like in plain mongoose:
+
+```ts
+class SomeTypegooseClass {
+  @prop()
+  public normalProp?: string;
+
+  @prop({ type: () => Passthrough({ somePath: String }) })
+  public passed?: { somePath: string };
+}
+
+// would be equal to
+
+new mongoose.Schema({
+  normalProp: {
+    type: String
+  },
+  passed: {
+    type: {
+      somePath: String
+    }
+  }
+})
+```

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -290,3 +290,28 @@ export function getDiscriminatorModelForClass<U extends AnyParamConstructor<any>
 
   return addModelToTypegoose<U, QueryHelpers>(model, cl);
 }
+
+/**
+ * Use this class if raw mongoose for this path is wanted
+ * It is still recommended to use the typegoose classes directly for full type and validation support
+ * Note: using this, paths are of type "Mixed" (with some validation)
+ * @example
+ * ```ts
+ * class Dummy {
+ *   @prop({ type: () => new Passthrough({ somePath: String }) })
+ *   public somepath: { somePath: string };
+ * }
+ * ```
+ */
+// Note: for "SchemaDefinitionType", i have no clue what it does, but it is also defined on "mongoose.Schema" and kinda required for "mongoose.DocumentDefinition"
+export class Passthrough<SchemaDefinitionType = undefined> {
+  public raw: mongoose.SchemaDefinition<mongoose.DocumentDefinition<SchemaDefinitionType>>;
+
+  /**
+   * Use this like `new mongoose.Schema()`
+   * @param raw the Schema definition
+   */
+  constructor(raw: mongoose.SchemaDefinition<mongoose.DocumentDefinition<SchemaDefinitionType>>) {
+    this.raw = raw;
+  }
+}


### PR DESCRIPTION
Add the `Passthrough` class to directly embed paths, like mongoose would allow

## Related Issues

- fixes typegoose/typegoose#382

---

~~WIP because it still needs testing~~