### PR TITLE
Update to Mongoose 6.0

### DIFF
--- a/docs/api/decorators/prop.md
+++ b/docs/api/decorators/prop.md
@@ -846,13 +846,13 @@ For Examples, look at:
 ## Passthrough Class
 
 :::caution
-It is not recommended to use this class, it should always be another class if nesting (and proper validation) like [in the quick-start-guide](../../guides/quick-start-guide.md#quick-overview-of-typegoose) is wanted
+It is not recommended to use this class, it should always be another class if nesting, like [in the quick-start-guide](../../guides/quick-start-guide.md/#quick-overview-of-typegoose) is wanted
 :::
 
-The `Passthrough` class is, like the name implies, to pass-through an schema definition directly, without "wrapping" it in a `new Schema({}` call.
+The `Passthrough` class is, like the name implies, to pass-through an schema definition directly, without "wrapping" it in a `new Schema({}` by typegoose call, but since mongoose 6.0 this is the same as doing another class (see [Mongoose#7181](https://github.com/Automattic/mongoose/issues/7181).
 
 :::note
-It should be noted that using this method (even in plain mongoose) will result in these paths to become `mongoose.Schema.Types.Mixed` (see [Mongoose#7181](https://github.com/Automattic/mongoose/issues/7181)), and also no typegoose transformations or warnings will be applied to what is inside `Passthrough` (like `type: () => Class` will not be translated, it will stay as-is)
+It should be noted that using this method no typegoose transformations or warnings will be applied to what is inside `Passthrough` (like `type: () => Class` will not be translated, it will stay as-is)
 :::
 
 The following example is what it looks like in typegoose, and what it would look like in plain mongoose:

--- a/docs/guides/advanced/class-transformer.md
+++ b/docs/guides/advanced/class-transformer.md
@@ -18,9 +18,11 @@ import { getModelForClass, mongoose, prop } from 'typegoose';
 class DocumentCT {
   @Expose()
   // makes sure that when deserializing from a Mongoose Object, ObjectId is serialized into a string
-  @Transform((value: any) => {
+  @Transform((value) => {
     if ('value' in value) {
-      return value.value instanceof mongoose.Types.ObjectId ? value.value.toHexString() : value.value.toString();
+      // HACK: this is changed because of https://github.com/typestack/class-transformer/issues/879
+      // return value.value.toString(); // because "toString" is also a wrapper for "toHexString"
+      return value.obj[value.key].toString();
     }
 
     return 'unknown value';

--- a/docs/guides/migrate-9.md
+++ b/docs/guides/migrate-9.md
@@ -1,0 +1,14 @@
+---
+id: migrate-9
+title: 'Migrate to 9.0.0'
+---
+
+These are the changes made for 9.0.0 that are breaking or just important to know
+
+## Requirements changed
+
+- Mongoose `6.0.1` or [higher is now required](#mongoose-60-is-now-supported)
+
+## Mongoose 6.0 is now supported
+
+Mongoose version `6.0.1` (and possibly higher) is now supported, for mongoose specific migration, look at the [6.0 migration guide](https://mongoosejs.com/docs/migrating_to_6.html)

--- a/docs/guides/migrate-9.md
+++ b/docs/guides/migrate-9.md
@@ -12,3 +12,7 @@ These are the changes made for 9.0.0 that are breaking or just important to know
 ## Mongoose 6.0 is now supported
 
 Mongoose version `6.0.1` (and possibly higher) is now supported, for mongoose specific migration, look at the [6.0 migration guide](https://mongoosejs.com/docs/migrating_to_6.html)
+
+## Class-transformer transform of "ObjectId" became broken
+
+Since mongodb 5.0 (mongoose 6.0) the `value` in `@Transform` is not equals to `obj[key]` anymore, see [the updated Class-Transformer Guide](./advanced/class-transformer.md#implementation) and [the Issue about this](https://github.com/typestack/class-transformer/issues/879)

--- a/docs/guides/mongoose-compatibility.csv
+++ b/docs/guides/mongoose-compatibility.csv
@@ -1,4 +1,5 @@
 Typegoose Version,Mongoose Version
+9.0.x,~6.0.1
 8.2.x,~5.13.8
 8.1.x,~5.13.3
 8.0.x,~5.13.3

--- a/docs/guides/mongoose-compatibility.md
+++ b/docs/guides/mongoose-compatibility.md
@@ -8,6 +8,7 @@ title: 'Mongoose Compatibility'
 <!--Everything below here is generated as stated above-->
 | Typegoose Version | Mongoose Version |
 | ----------------- | ---------------- |
+| 9.0.x             | ~6.0.1           |
 | 8.2.x             | ~5.13.8          |
 | 8.1.x             | ~5.13.3          |
 | 8.0.x             | ~5.13.3          |

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "mongoose": "~5.13.8"
+    "mongoose": "~6.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",
@@ -62,7 +62,7 @@
     "jest": "^27.0.6",
     "lint-staged": "^11.1.2",
     "mongodb-memory-server": "^7.3.6",
-    "mongoose": "~5.13.8",
+    "mongoose": "~6.0.1",
     "mongoose-findorcreate": "^3.0.0",
     "prettier": "^2.3.2",
     "rimraf": "^3.0.2",

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -161,7 +161,7 @@ export function getClassForDocument(document: mongoose.Document): NewableFunctio
 export function getClass(
   input:
     | (mongoose.Document & IObjectWithTypegooseFunction)
-    | (mongoose.Schema.Types.Embedded & IObjectWithTypegooseFunction)
+    | (mongoose.Schema.Types.Subdocument & IObjectWithTypegooseFunction)
     | string
     | IObjectWithTypegooseName
     | any
@@ -457,7 +457,7 @@ export function mapOptions(
   let OptionsCTOR: undefined | AnyParamConstructor<any> = Type?.prototype?.OptionsConstructor;
 
   if (Type instanceof mongoose.Schema) {
-    OptionsCTOR = mongoose.Schema.Types.Embedded.prototype.OptionsConstructor;
+    OptionsCTOR = mongoose.Schema.Types.Subdocument.prototype.OptionsConstructor;
   }
 
   assertion(

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -293,8 +293,8 @@ export function getDiscriminatorModelForClass<U extends AnyParamConstructor<any>
 
 /**
  * Use this class if raw mongoose for this path is wanted
- * It is still recommended to use the typegoose classes directly for full type and validation support
- * @see Using `Passthrough`, the paths created will result in `Mixed`, see {@link https://github.com/Automattic/mongoose/issues/7181 Mongoose#7181}
+ * It is still recommended to use the typegoose classes directly
+ * @see Using `Passthrough`, the paths created will also result as an `Schema` (since mongoose 6.0), see {@link https://github.com/Automattic/mongoose/issues/7181 Mongoose#7181}
  * @example
  * ```ts
  * class Dummy {

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,7 +94,7 @@ export interface BasePropOptions {
    * Should this property have an "expires" index?
    * @link https://docs.mongodb.com/manual/tutorial/expire-data
    */
-  expires?: string | number /* mongoose.SchemaTypeOptions<any>['expires'] */; // TODO: change to get from mongoose, when https://github.com/Automattic/mongoose/issues/10529 resolved
+  expires?: mongoose.SchemaTypeOptions<any>['expires'];
   /**
    * Should this property have an "text" index?
    * @link https://mongoosejs.com/docs/api.html#schematype_SchemaType-text

--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -1,7 +1,7 @@
 import { MongoMemoryServer } from 'mongodb-memory-server';
-import * as mongoose from 'mongoose';
 import { logger } from '../src/logSettings';
 import { config } from './utils/config';
+import { connect } from './utils/connect';
 
 export = async function globalSetup() {
   logger.setLevel('DEBUG');
@@ -16,7 +16,7 @@ export = async function globalSetup() {
     process.env.MONGO_URI = `mongodb://${config.IP}:${config.Port}`;
   }
 
-  await mongoose.connect(`${process.env.MONGO_URI}/${config.DataBase}`, { useNewUrlParser: true, useUnifiedTopology: true });
-  await mongoose.connection.db.dropDatabase();
-  await mongoose.disconnect();
+  const connection = await connect({ dbName: config.DataBase });
+  await connection.db.dropDatabase();
+  await connection.close();
 };

--- a/test/tests/__snapshots__/biguser.test.ts.snap
+++ b/test/tests/__snapshots__/biguser.test.ts.snap
@@ -3,11 +3,11 @@
 exports[`should create a User with connections 1`] = `
 Object {
   "__v": 0,
-  "_id": Any<ObjectID>,
+  "_id": Any<ObjectId>,
   "age": 20,
   "car": Object {
     "__v": 0,
-    "_id": Any<ObjectID>,
+    "_id": Any<ObjectId>,
     "carModel": "Tesla",
     "id": Any<String>,
     "price": Object {
@@ -20,10 +20,8 @@ Object {
   "gender": "male",
   "id": Any<String>,
   "job": Object {
-    "id": null,
     "jobType": Object {
       "field": "IT",
-      "id": null,
       "salery": 5000,
     },
     "position": "Lead",

--- a/test/tests/classTransformer.test.ts
+++ b/test/tests/classTransformer.test.ts
@@ -1,14 +1,16 @@
 import { classToPlain, Exclude, Expose, plainToClass, Transform } from 'class-transformer';
-import { getModelForClass, mongoose, prop } from '../../src/typegoose';
+import { getModelForClass, prop } from '../../src/typegoose';
 
 // re-implement base Document to allow class-transformer to serialize/deserialize its properties
 // This class is needed, otherwise "_id" and "__v" would be excluded from the output
 class DocumentCT {
   @Expose()
   // makes sure that when deserializing from a Mongoose Object, ObjectId is serialized into a string
-  @Transform((value: any) => {
+  @Transform((value) => {
     if ('value' in value) {
-      return value.value instanceof mongoose.Types.ObjectId ? value.value.toHexString() : value.value.toString();
+      // HACK: this is changed because of https://github.com/typestack/class-transformer/issues/879
+      // return value.value.toString(); // because "toString" is also a wrapper for "toHexString"
+      return value.obj[value.key].toString();
     }
 
     return 'unknown value';

--- a/test/tests/ref.test.ts
+++ b/test/tests/ref.test.ts
@@ -384,8 +384,8 @@ it('should map options correctly on an ref-array', async () => {
   const reference2 = await RefArrayOptionsMappingNestedModel.create({ dummy: 'hello2' });
   expect(reference2).toBeDefined();
   await RefArrayOptionsMappingModel.create({ validatedRef: reference2, validatedRefArray: [reference2, reference2] });
-  expect(validateInner).toBeCalledWith(reference2);
-  expect(validateOuter).toHaveBeenNthCalledWith(1, expect.arrayContaining([reference2, reference2]));
+  expect(validateInner).toBeCalledWith(reference2._id);
+  expect(validateOuter).toHaveBeenNthCalledWith(1, expect.arrayContaining([reference2._id, reference2._id]));
   expect(validateOuter).toHaveBeenNthCalledWith(2, expect.any(Array));
 
   jest.clearAllMocks();
@@ -393,9 +393,9 @@ it('should map options correctly on an ref-array', async () => {
   const reference3 = await RefArrayOptionsMappingNestedModel.create({ dummy: 'hello3' });
   expect(reference3).toBeDefined();
   await RefArrayOptionsMappingModel.create({ explicitDoubleRefArray: [reference3, reference3] });
-  expect(validateInner).toBeCalledWith(reference3);
+  expect(validateInner).toBeCalledWith(reference3._id);
   // the order is different, because defaults get created *after* normal values, and so validatorss of those defaults are also called later
-  expect(validateOuter).toHaveBeenNthCalledWith(1, expect.arrayContaining([reference3, reference3]));
+  expect(validateOuter).toHaveBeenNthCalledWith(1, expect.arrayContaining([reference3._id, reference3._id]));
   expect(validateOuter).toHaveBeenNthCalledWith(2, expect.any(Array));
 });
 

--- a/test/tests/ref.test.ts
+++ b/test/tests/ref.test.ts
@@ -433,7 +433,7 @@ it('Reference-Maps should work and be populated', async () => {
     expect(v).toBeInstanceOf(mongoose.Types.ObjectId);
   });
 
-  await found.populate('mapped.$*').execPopulate();
+  await found.populate('mapped.$*');
 
   const found_doc1 = found.mapped.get('1');
   assertion(isDocument(found_doc1));

--- a/test/tests/shouldAdd.test.ts
+++ b/test/tests/shouldAdd.test.ts
@@ -219,8 +219,7 @@ it('should add options to ref [szokodiakos#379]', () => {
   const someprop = schema.path('someprop');
   expect(schema).not.toBeUndefined();
   expect(someprop).not.toBeUndefined();
-  // @ts-expect-error because "options" dosnt exist on "SchemaType"
-  const opt: any = someprop.options;
+  const opt: mongoose.SchemaTypeOptions<any> = someprop.options;
   expect(typeof opt.type).toEqual('function');
   expect(opt.ref).toEqual('T');
   expect(opt).toHaveProperty('customoption', 'custom');
@@ -241,8 +240,7 @@ it('should add options to refPath [szokodiakos#379]', () => {
   const someprop = schema.path('someprop');
   expect(schema).not.toBeUndefined();
   expect(someprop).not.toBeUndefined();
-  // @ts-expect-error because "options" dosnt exist on "SchemaType"
-  const opt: any = someprop.options;
+  const opt: mongoose.SchemaTypeOptions<any> = someprop.options;
   expect(typeof opt.type).toEqual('function');
   expect(opt.refPath).toEqual('something');
   expect(opt).toHaveProperty('customoption', 'custom');
@@ -260,10 +258,9 @@ it('should add options to array-ref [szokodiakos#379]', () => {
   const someprop = schema.path('someprop');
   expect(schema).toBeDefined();
   expect(someprop).toBeDefined();
-  // @ts-expect-error because "options" dosnt exist on "SchemaType"
-  expect(someprop.options).toHaveProperty('customoption1', 'custom1');
-  // @ts-expect-error because "options" dosnt exist on "SchemaType"
-  const opt: any = someprop.options.type[0];
+  const preopts: mongoose.SchemaTypeOptions<any> = someprop.options;
+  expect(preopts).toHaveProperty('customoption1', 'custom1');
+  const opt: mongoose.SchemaTypeOptions<any> = preopts.type![0];
   expect(typeof opt.type).toEqual('function');
   expect(opt.ref).toEqual(getName(TestArrayRefNested));
   expect(opt).toHaveProperty('customoption2', 'custom2');
@@ -285,10 +282,9 @@ it('should add options to array-refPath [szokodiakos#379]', () => {
   expect(schema).toBeDefined();
   expect(someprop).toBeDefined();
   expect(someprop).toBeInstanceOf(mongoose.Schema.Types.Array);
-  // @ts-expect-error because "options" dosnt exist on "SchemaType"
-  expect(someprop.options).toHaveProperty('customoption1', 'custom1');
-  // @ts-expect-error because "options" dosnt exist on "SchemaType"
-  const opt: any = someprop.options.type[0];
+  const preopts: mongoose.SchemaTypeOptions<any> = someprop.options;
+  expect(preopts).toHaveProperty('customoption1', 'custom1');
+  const opt: mongoose.SchemaTypeOptions<any> = preopts.type![0];
   expect(typeof opt.type).toEqual('function');
   expect(opt.refPath).toEqual('something');
   expect(opt).toHaveProperty('customoption2', 'custom2');

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -504,7 +504,7 @@ it('should allow Maps with SubDocument "Map<string SubDocument>"', async () => {
   const casterNestingPath = nestingPath['$__schemaType'];
 
   expect(nestingPath).toBeInstanceOf(mongoose.Schema.Types.Map);
-  expect(casterNestingPath).toBeInstanceOf(mongoose.Schema.Types.Embedded);
+  expect(casterNestingPath).toBeInstanceOf(mongoose.Schema.Types.Subdocument);
   expect(casterNestingPath.schema.path('dummy')).toBeInstanceOf(mongoose.Schema.Types.String);
   expect(casterNestingPath.schema.paths).not.toHaveProperty('_id');
 });

--- a/test/tests/typeguards.test.ts
+++ b/test/tests/typeguards.test.ts
@@ -24,7 +24,7 @@ describe('isDocument / isDocumentArray', () => {
 
     UserMaster.subAccounts.push(UserSub._id);
 
-    await UserMaster.populate('subAccounts').execPopulate();
+    await UserMaster.populate('subAccounts');
 
     if (isDocumentArray(UserMaster.subAccounts)) {
       expect(UserMaster.subAccounts).toHaveLength(1);
@@ -47,7 +47,7 @@ describe('isDocument / isDocumentArray', () => {
 
     UserSub.master = UserMaster._id;
 
-    await UserSub.populate('master').execPopulate();
+    await UserSub.populate('master');
 
     if (isDocument(UserSub.master)) {
       expect(UserSub.master.name).toEqual('master');
@@ -109,11 +109,11 @@ describe('isDocument / isDocumentArray', () => {
       master: User2._id,
     });
 
-    await User3.populate('master').execPopulate();
+    await User3.populate('master');
 
     if (isDocument(User3.master)) {
       // User3.master === User2
-      await User3.master.populate('master').execPopulate();
+      await User3.master.populate('master');
 
       if (isDocument(User3.master.master)) {
         // User3.master.master === User1
@@ -130,7 +130,7 @@ describe('isDocument / isDocumentArray', () => {
       populate: {
         path: 'master',
       },
-    }).execPopulate();
+    });
   });
 
   it('should handle recursive populations - single populate', async () => {
@@ -151,7 +151,7 @@ describe('isDocument / isDocumentArray', () => {
       populate: {
         path: 'master',
       },
-    }).execPopulate();
+    });
 
     if (isDocument(User3.master) && isDocument(User3.master.master)) {
       // User3.master === User2 && User3.master.master === User1

--- a/test/utils/connect.ts
+++ b/test/utils/connect.ts
@@ -35,7 +35,7 @@ export async function connect(extraConfig: ExtraConnectionConfig = {}): Promise<
   const connectionString = `${process.env.MONGO_URI}/${extraConfig.dbName ?? config.DataBase}`;
 
   if (extraConfig.createNewConnection) {
-    connection = mongooseInstance.createConnection(connectionString, options);
+    connection = await mongooseInstance.createConnection(connectionString, options).asPromise();
   } else {
     await mongoose.connect(connectionString, options);
     connection = mongooseInstance.connection;

--- a/test/utils/connect.ts
+++ b/test/utils/connect.ts
@@ -9,10 +9,6 @@ interface ExtraConnectionConfig {
 
 // to not duplicate code
 const staticOptions: mongoose.ConnectOptions = {
-  useNewUrlParser: true,
-  useFindAndModify: true,
-  useCreateIndex: true,
-  useUnifiedTopology: true,
   autoIndex: true,
 };
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -10,6 +10,6 @@ module.exports = {
     "Getting Started": ["guides/quick-start-guide", "guides/faq", "guides/known-issues", "guides/deprecation-codes", "guides/error-warning-details"],
     Basics: ["guides/all-decorators", "guides/motivation", "guides/default-classes", "guides/use-without-emitDecoratorMetadata"],
     Advanced: ["guides/advanced/custom-types", "guides/advanced/array-types", "guides/advanced/models-with-same-name", "guides/advanced/logger", "guides/advanced/reference-other-classes", "guides/advanced/common-plugins", "guides/advanced/change-id-type", "guides/advanced/using-objectid-type", "guides/advanced/using-with-class-transformer", "guides/advanced/non-nested-discriminators"],
-    Migration: ["guides/mongoose-compatibility", "guides/migrate-8", "guides/migrate-7", "guides/migrate-6"]
+    Migration: ["guides/mongoose-compatibility", "guides/migrate-9", "guides/migrate-8", "guides/migrate-7", "guides/migrate-6"]
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,13 +1079,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/bson@*":
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/@types/bson/-/bson-4.0.5.tgz#9e0e1d1a6f8866483f96868a9b33bc804926b1fc"
-  integrity sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -1135,18 +1128,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/mongodb@^3.5.27":
-  version "3.6.20"
-  resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.6.20.tgz#b7c5c580644f6364002b649af1c06c3c0454e1d2"
-  integrity sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==
-  dependencies:
-    "@types/bson" "*"
-    "@types/node" "*"
-
 "@types/node@*":
-  version "16.4.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.10.tgz#e57e2a54fc6da58da94b3571b1cb456d39f88597"
-  integrity sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ==
+  version "16.7.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.1.tgz#c6b9198178da504dfca1fd0be9b2e1002f1586f0"
+  integrity sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==
 
 "@types/node@~12.12.6":
   version "12.12.70"
@@ -1187,6 +1172,19 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.1.tgz#83ecf4ec22a8c218c71db25f316619fe5b986011"
   integrity sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg==
+
+"@types/webidl-conversions@*":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz#e33bc8ea812a01f63f90481c666334844b12a09e"
+  integrity sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q==
+
+"@types/whatwg-url@^8.2.1":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@types/whatwg-url/-/whatwg-url-8.2.1.tgz#f1aac222dab7c59e011663a0cb0a3117b2ef05d4"
+  integrity sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/webidl-conversions" "*"
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -1639,11 +1637,6 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bluebird@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
-  integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
-
 bottleneck@^2.18.1:
   version "2.19.5"
   resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
@@ -1699,6 +1692,13 @@ bson@^1.1.4:
   resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.6.tgz#fb819be9a60cd677e0853aee4ca712a785d6618a"
   integrity sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==
 
+bson@^4.2.2, bson@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-4.5.1.tgz#02e9d649ce017ab14ed258737756c11809963d6c"
+  integrity sha512-XqFP74pbTVLyLy5KFxVfTUyRrC1mgOlmu/iXHfXqfCKT59jyP9lwbotGfbN59cHBRbJSamZNkrSopjv+N0SqAA==
+  dependencies:
+    buffer "^5.6.0"
+
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
@@ -1709,7 +1709,7 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-buffer@^5.5.0:
+buffer@^5.5.0, buffer@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -2167,14 +2167,7 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2:
+debug@4, debug@4.x, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -2259,6 +2252,11 @@ denque@^1.4.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.0.tgz#773de0686ff2d8ec2ff92914316a47b73b1c73de"
   integrity sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==
+
+denque@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.1.tgz#07f670e29c9a78f8faecb2566a1e2c11929c5cbf"
+  integrity sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==
 
 depd@^1.1.2:
   version "1.1.2"
@@ -4555,6 +4553,14 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+mongodb-connection-string-url@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-2.0.0.tgz#72cea65084ffa45655670070efb57bb0a5da46bc"
+  integrity sha512-M0I1vyLoq5+HQTuPSJWbt+hIXsMCfE8sS1fS5mvP9R2DOMoi2ZD32yWqgBIITyu0dFu4qtS50erxKjvUeBiyog==
+  dependencies:
+    "@types/whatwg-url" "^8.2.1"
+    whatwg-url "^9.1.0"
+
 mongodb-memory-server-core@7.3.6:
   version "7.3.6"
   resolved "https://registry.yarnpkg.com/mongodb-memory-server-core/-/mongodb-memory-server-core-7.3.6.tgz#9c16cf120e498011a8702e7735271cbe878dd6e5"
@@ -4586,10 +4592,21 @@ mongodb-memory-server@^7.3.6:
     mongodb-memory-server-core "7.3.6"
     tslib "^2.3.0"
 
-mongodb@3.6.11, mongodb@^3.6.9:
-  version "3.6.11"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.6.11.tgz#8a59a0491a92b00a8c925f72ed9d9a5b054aebb2"
-  integrity sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==
+mongodb@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.1.1.tgz#d328e832675e7351f58b642f833126dc89ac2e66"
+  integrity sha512-fbACrWEyvr6yl0sSiCGV0sqEiBwTtDJ8iSojmkDjAfw9JnOZSAkUyv9seFSPYhPPKwxp1PDtyjvBNfMDz0WBLQ==
+  dependencies:
+    bson "^4.5.1"
+    denque "^1.5.0"
+    mongodb-connection-string-url "^2.0.0"
+  optionalDependencies:
+    saslprep "^1.0.0"
+
+mongodb@^3.6.9:
+  version "3.6.10"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.6.10.tgz#f10e990113c86b195c8af0599b9b3a90748b6ee4"
+  integrity sha512-fvIBQBF7KwCJnDZUnFFy4WqEFP8ibdXeFANnylW19+vOwdjOAvqIzPdsNCEMT6VKTHnYu4K64AWRih0mkFms6Q==
   dependencies:
     bl "^2.2.1"
     bson "^1.1.4"
@@ -4604,27 +4621,18 @@ mongoose-findorcreate@^3.0.0:
   resolved "https://registry.yarnpkg.com/mongoose-findorcreate/-/mongoose-findorcreate-3.0.0.tgz#490acf67c16061de74f7d1b92906538a62554a6d"
   integrity sha512-kQhDe5XDj6tMv8kq1wjK+hITGIGUl60rj8oGLupF9poNsqIDkAJBXudZKcCdSyBZ7p6DLK2+0jSBthrb26tSYQ==
 
-mongoose-legacy-pluralize@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz#3ba9f91fa507b5186d399fb40854bff18fb563e4"
-  integrity sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==
-
-mongoose@~5.13.8:
-  version "5.13.8"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.13.8.tgz#1477c306b9f1d1c737ad95ce1b4acac9aec4a421"
-  integrity sha512-z3d+qei9Dem/LxRcJi0cdGPKzQnYk71oHEsEfYm17JA/vLiAbJiGuBS2hW7vkd9afkPAqu3KsPZh2ax0c5iPQw==
+mongoose@~6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-6.0.1.tgz#56f8604c2bf584a200746e7f64e5d65d483ffe41"
+  integrity sha512-WESkAtJuJqXKjiQj+HiL3Ipr6eLWx9RIrjCE2HzxScUApnFLXSHdd5gGCeEE3Pl+qcill4fGYy/uysThCMQ6PQ==
   dependencies:
-    "@types/mongodb" "^3.5.27"
-    bson "^1.1.4"
+    bson "^4.2.2"
     kareem "2.3.2"
-    mongodb "3.6.11"
-    mongoose-legacy-pluralize "1.0.2"
+    mongodb "4.1.1"
     mpath "0.8.3"
-    mquery "3.2.5"
+    mquery "4.0.0"
     ms "2.1.2"
-    optional-require "1.0.x"
     regexp-clone "1.0.0"
-    safe-buffer "5.2.1"
     sift "13.5.2"
     sliced "1.0.1"
 
@@ -4633,21 +4641,14 @@ mpath@0.8.3:
   resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.8.3.tgz#828ac0d187f7f42674839d74921970979abbdd8f"
   integrity sha512-eb9rRvhDltXVNL6Fxd2zM9D4vKBxjVVQNLNijlj7uoXUy19zNDsIif5zR+pWmPCWNKwAtqyo4JveQm4nfD5+eA==
 
-mquery@3.2.5:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/mquery/-/mquery-3.2.5.tgz#8f2305632e4bb197f68f60c0cffa21aaf4060c51"
-  integrity sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==
+mquery@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mquery/-/mquery-4.0.0.tgz#6c62160ad25289e99e0840907757cdfd62bde775"
+  integrity sha512-nGjm89lHja+T/b8cybAby6H0YgA4qYC/lx6UlwvHGqvTq8bDaNeCwl1sY8uRELrNbVWJzIihxVd+vphGGn1vBw==
   dependencies:
-    bluebird "3.5.1"
-    debug "3.1.0"
+    debug "4.x"
     regexp-clone "^1.0.0"
-    safe-buffer "5.1.2"
     sliced "1.0.1"
-
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
 ms@2.1.2:
   version "2.1.2"
@@ -4991,10 +4992,12 @@ opener@^1.5.2:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
-optional-require@1.0.x, optional-require@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/optional-require/-/optional-require-1.0.3.tgz#275b8e9df1dc6a17ad155369c2422a440f89cb07"
-  integrity sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==
+optional-require@^1.0.3:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/optional-require/-/optional-require-1.1.7.tgz#9ab5b254f59534108d4b2201d9ae96a063abc015"
+  integrity sha512-cIeRZocXsZnZYn+SevbtSqNlLbeoS4mLzuNn4fvXRMDRNhTGg0sxuKXl0FnZCtnew85LorNxIbZp5OeliILhMw==
+  dependencies:
+    require-at "^1.0.6"
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -5544,6 +5547,11 @@ request@^2.88.2:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
+require-at@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/require-at/-/require-at-1.0.6.tgz#9eb7e3c5e00727f5a4744070a7f560d4de4f6e6a"
+  integrity sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -5630,15 +5638,15 @@ rxjs@^6.6.7:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
@@ -6543,6 +6551,14 @@ whatwg-url@^8.0.0, whatwg-url@^8.5.0:
   integrity sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==
   dependencies:
     lodash "^4.7.0"
+    tr46 "^2.1.0"
+    webidl-conversions "^6.1.0"
+
+whatwg-url@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-9.1.0.tgz#1b112cf237d72cd64fa7882b9c3f6234a1c3050d"
+  integrity sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==
+  dependencies:
     tr46 "^2.1.0"
     webidl-conversions "^6.1.0"
 


### PR DESCRIPTION
Update to work with Mongoose 6.0 and MongoDB 4.0

## Related Issues

- https://github.com/Automattic/mongoose/issues/10506
- https://github.com/Automattic/mongoose/issues/10518
- https://github.com/Automattic/mongoose/issues/10576
- https://github.com/Automattic/mongoose/pull/10577

## Blocked By

- [x] https://github.com/Automattic/mongoose/issues/10508
- [x] https://github.com/Automattic/mongoose/issues/10509
- [x] https://github.com/Automattic/mongoose/issues/10511
- [x] https://github.com/Automattic/mongoose/issues/10522
- [x] https://github.com/typegoose/typegoose/issues/586
- [x] https://github.com/Automattic/mongoose/issues/10585
- [ ] https://github.com/typestack/class-transformer/issues/879

---

Note: `Related Issues` this time also includes `things noticed by upgrading (and made an issue about in mongoose), but not breaking`
Note: `Blocked By` means that until these are fixed, it is not expected mongoose 6.0 will even start to work with typegoose (even before release)

this is WIP, until 6.0 is released
Note: this PR will be rebased many times to update the mongoose version

PS: the base branch will be changed to `beta` once development starts on beta
