### PR TITLE
docs(quick-start-guide): remove arrow function in hooks example

### DIFF
--- a/docs/guides/quick-start-guide.md
+++ b/docs/guides/quick-start-guide.md
@@ -237,7 +237,7 @@ Typegoose also supports hooks. They can be used like this:
 @pre<KittenClass>('save', function() {
   this.isKitten = this.age < 1
 })
-@post<KittenClass>('save', (kitten) => {
+@post<KittenClass>('save', function(kitten) {
   console.log(kitten.isKitten ? 'We have a kitten here.' : 'We have a big kitty here.')
 })
 class KittenClass {


### PR DESCRIPTION
<!--
Try to use a template, found at .github/PULL_REQUEST_TEMPLATE/
[here](https://github.com/typegoose/typegoose/tree/master/.github/PULL_REQUEST_TEMPLATE)
please don't forget to click on raw, and copy that, not the already "compiled" one
-->

<!--
## Make sure you have done these steps

- Make sure you have Read & followed these steps in [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

<!--Write your PR description here (above "Related Issues")-->
<!--
## Make sure you have done these steps

- Make sure you have Read & followed these steps in [CONTRIBUTING](.github/CONTRIBUTING.md)
- in "Adds Documentation for" remove the "(#) when there is no issue for it
- remove the parts that are not applicable
-->

## Updates Documentation for quick-start-guide

Since one of the notes says:
> - Do not use Arrow Functions, because it will break the binding of `this`

The hooks usage example shouldn't expose arrow functions as a valid way to use it

## Related Issues

<!--add "fixes" / "closes" before an number to indicate that these will be fixed by this pr-->
