### PR TITLE
fix import of  mongoose-autopopulate

### DIFF
--- a/docs/guides/integration-examples/common-plugins.md
+++ b/docs/guides/integration-examples/common-plugins.md
@@ -25,7 +25,7 @@ import * as mongoose from 'mongoose';
 import autopopulate from 'mongoose-autopopulate';
 import { plugin, prop, Ref, getModelForClass } from '@typegoose/typegoose';
 
-@plugin(autopopulate as any) // this is a dirty fix, because the types of this plugin dont work
+@plugin(autopopulate)
 class SomeClass {
   @prop({ autopopulate: true, ref: 'SomeReferencedClass' })
   public populateField: Ref<SomeReferencedClass>;

--- a/docs/guides/integration-examples/common-plugins.md
+++ b/docs/guides/integration-examples/common-plugins.md
@@ -22,7 +22,7 @@ Typegoose has the prop option `autopopulate` implemented, but it only has an eff
 
 ```ts
 import * as mongoose from 'mongoose';
-import * as autopopulate from 'mongoose-autopopulate';
+import autopopulate from 'mongoose-autopopulate';
 import { plugin, prop, Ref, getModelForClass } from '@typegoose/typegoose';
 
 @plugin(autopopulate as any) // this is a dirty fix, because the types of this plugin dont work


### PR DESCRIPTION
Schema was throwing error following error if using mongoose-autopopulate according to doc:
throw new Error('First param to `schema.plugin()` must be a function, ' +
          ^
Error: First param to `schema.plugin()` must be a function, got "object"

I directly import the default export of mongoose-autopopulate and it works

<!--
Try to use a template, found at .github/PULL_REQUEST_TEMPLATE/
[here](https://github.com/typegoose/typegoose/tree/master/.github/PULL_REQUEST_TEMPLATE)
please don't forget to click on raw, and copy that, not the already "compiled" one
-->

<!--
## Make sure you have done these steps

- Make sure you have Read & followed these steps in [CONTRIBUTING](https://github.com/typegoose/typegoose/tree/master/.github/CONTRIBUTING.md)
- remove the parts that are not applicable
- Please have "Allow edits from maintainers" activated
-->

<!--Write your PR description here (above "Related Issues")-->
