### PR TITLE
fix: error mongoose version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "mongoose": "~6.1.6"
+    "mongoose": "~6.2.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/418820/152813332-00575952-9f78-4e9c-ad02-513a7294657c.png)

![image](https://user-images.githubusercontent.com/418820/152813575-4148664a-9c7c-4e08-aaed-ca77a954fb2f.png)

Typgoose require mongoose@6.1.6 in package.json but require mongoose@6.2.0 in code.