### PR TITLE
Adds an actual description to website

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   title: 'typegoose',
-  description: 'Define Mongoose models using TypeScript classes',
   tagline: 'Define Mongoose models using TypeScript classes',
   url: 'https://typegoose.github.io',
   baseUrl: '/typegoose/',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   title: 'typegoose',
+  description: 'Define Mongoose models using TypeScript classes',
   tagline: 'Define Mongoose models using TypeScript classes',
   url: 'https://typegoose.github.io',
   baseUrl: '/typegoose/',

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -43,7 +43,7 @@ function Home() {
   const { siteConfig = {} } = context;
 
   return (
-    <Layout title={`Welcome to ${siteConfig.title}`} description="Description will go into a meta tag in <head />">
+    <Layout title={`Welcome to ${siteConfig.title}`} description={siteConfig.description}>
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">
           <h1 className="hero__title">{siteConfig.title}</h1>

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -43,7 +43,7 @@ function Home() {
   const { siteConfig = {} } = context;
 
   return (
-    <Layout title={`Welcome to ${siteConfig.title}`} description={siteConfig.description}>
+    <Layout title={`Welcome to ${siteConfig.title}`} description={siteConfig.tagline}>
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">
           <h1 className="hero__title">{siteConfig.title}</h1>


### PR DESCRIPTION
Added a config key to `website/docusaurus.config.js` and used it in `website/src/pages/index.js` to prevent this:

![image](https://user-images.githubusercontent.com/10481749/161011837-4618859e-a634-40eb-9f7a-adc004e64a73.png)

Not gonna lie: I tried to `yarn run website` but couldn't for the life of me run docusaurus on my system.

Only two lines changed tho...