### PR TITLE
fix(docs): fix typo for prop.md

### DIFF
--- a/docs/api/decorators/prop.md
+++ b/docs/api/decorators/prop.md
@@ -5,7 +5,7 @@ title: '@prop'
 
 `@prop(options: object, kind: PropType)` is used for setting properties in a Class (without this set, it is just a type and will **NOT** be in the final model/document)
 - `options` is to set [all options](#single-options)
-- `kind` is to overwrite what kind of prop this is (should be auto-inferred), [read more here](#PropType)
+- `kind` is to overwrite what kind of prop this is (should be auto-inferred), [read more here](#proptype)
 
 ## Single Options
 


### PR DESCRIPTION
## Fixes Typo Documentation for

- prop.md

As you can see in the [link](https://typegoose.github.io/typegoose/docs/api/decorators/prop/) when you click to "read more here" nothing happens because there is case-sensitive typo.

![image](https://user-images.githubusercontent.com/59085992/169148042-ca05e999-20c6-48f4-a993-fe3f4acfdaa2.png)
