### PR TITLE
docs(hooks): fix post-hook documentation

### DIFF
--- a/docs/api/decorators/hooks.md
+++ b/docs/api/decorators/hooks.md
@@ -122,14 +122,10 @@ post<T>(method: QMR | QMR[], fn: PostQueryArrayWithError<T>, options?: mongoose.
 | `fn` <span class="badge badge--secondary">Required</span>     |                                         `Func`                                         | The Function to run for the Method(s) set in `method` |
 | `options`                                                     | [`mongoose.SchemaPreOptions`](https://mongoosejs.com/docs/api.html#schema_Schema-post) | Options to set when to run the hook                   |
 
-`@post` is used to set Pre-Hooks for many function, works like `schema.post` calls.  
+`@post` is used to set Post-Hooks for many function, works like `schema.post` calls.  
 `@post` currently supports `method` arrays that mongoose does not natively supports, may change in the future.
 
 For parameter `options`, look at the [mongoose for `schema.post`](https://mongoosejs.com/docs/api/schema.html#schema_Schema-post) or [mongoose Middleware section Naming Conflicts](https://mongoosejs.com/docs/middleware.html#naming).
-
-:::note
-Arrow Functions cannot be used here, because the binding of `this` is required to get & modify the Document / Query / Aggregate.
-:::
 
 ## Example {#post-example}
 

--- a/docs/api/decorators/hooks.md
+++ b/docs/api/decorators/hooks.md
@@ -127,6 +127,10 @@ post<T>(method: QMR | QMR[], fn: PostQueryArrayWithError<T>, options?: mongoose.
 
 For parameter `options`, look at the [mongoose for `schema.post`](https://mongoosejs.com/docs/api/schema.html#schema_Schema-post) or [mongoose Middleware section Naming Conflicts](https://mongoosejs.com/docs/middleware.html#naming).
 
+:::note
+Arrow Functions cannot be used here, because the binding of `this` is required to get & modify the Document / Query / Aggregate.
+:::
+
 ## Example {#post-example}
 
 ```ts


### PR DESCRIPTION
This PR fixes the Post-Hook documentation. There is a typo (Pre- instead of Post-Hook) and a false hint because there is no "this" inside of post hooks, instead one is accessing the document(s) affected by the post-hook-calling-method as shown in the example.

## Related Issues

- None.
