### PR TITLE
fix(scripts): use double quotes in lint file glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "build:tests": "tsc -p tsconfig.json",
-    "lint": "eslint -c ./.eslintrc.js './**/*.{js,ts}'",
+    "lint": "eslint -c ./.eslintrc.js \"./**/*.{js,ts}\"",
     "test": "jest",
     "test:watch": "jest --watchAll",
     "test:coverage": "jest --collectCoverage",


### PR DESCRIPTION
Currently with single quotes, the `lint` script in `package.json` isn't usable on windows.

## Related Issues

None