### PR TITLE
docs(syntax-notes): fix broken link, syntax error, and improve grammar

### DIFF
--- a/docs/guides/syntax-notes.md
+++ b/docs/guides/syntax-notes.md
@@ -7,7 +7,7 @@ This Page shows different possibilities of how code can be written in Typegoose,
 
 ## `type` & `ref` with function or without
 
-The options [`type`](../api/decorators/prop.md#type) and [`ref`](../api/decorators/prop.md#ref) can be written either as `type: Type` or as `type: () => Type`. Both syntax variations are valid options, but the second should always be preferred when not using primitives, because this "deferred function" syntax can  workaround the issues of [Circular References](./advanced/reference-other-classes.md#circular-dependencies) (in some cases) and also correct situations, where you might run into `use-before-declaration` errors.
+The options [`type`](../api/decorators/prop.md#type) and [`ref`](../api/decorators/prop.md#ref) can be written either as `type: Type` or as `type: () => Type`. Both syntax variations are valid options, but the second should always be preferred when not using primitives, because this "deferred function" syntax can workaround the issues of [Circular References](./advanced/reference-other-classes.md#circular-dependencies) (in some cases) and also correct situations where you might run into `use-before-declaration` errors.
 
 ```ts
 class Cat {
@@ -35,19 +35,20 @@ class Food {
 
 ## `type` with array or without
 
-When defining the [`type` in the `prop options`](../api/decorators/prop.md) for an array, the type can be written either as `type: Type` or as `type: [Type]`. Both are valid options and the differences are only cosmetic. However, if you're using more than 1 dimensions, it is *no longer* cosmetic and the type has to indicate the [number of dimensions](../api/decorators/prop#dim). This rule is valid for both [`type` & `ref` with function or without](#type--ref-with-function-or-without).
+When defining the [`type` in the `prop options`](../api/decorators/prop.md) for an array, the type can be written either as `type: Type` or as `type: [Type]`. Both are valid options and the differences are only cosmetic. However, if you're using more than 1 dimension, it is *no longer* cosmetic and the type has to indicate the [number of dimensions](../api/decorators/prop.md#dim). This rule is valid for both [`type` & `ref` with function or without](#type--ref-with-function-or-without).
 
 :::note
 If dimension syntax is used in the `ref` option, Typegoose will [throw an error](./error-warning-details.md#the-option-does-not-support-a-option-value-e027) because only `ref: Type` is allowed (no array).
 :::
 :::note
-Using dimensions, while not setting the property to be an array, will **not** set the type to an array. Use [the `@prop` decorator's second parameter](../api/decorators/prop.md) for that. Or alternatively, when [`emitDecoratorMetadata`](./use-without-emitDecoratorMetadata.md) is in use and the type is set correctly, then the array type will be set automatically too.)
+Using dimensions, while not setting the property to be an array, will **not** set the type to an array. Use [the `@prop` decorator's second parameter](../api/decorators/prop.md) for that. Or alternatively, when [`emitDecoratorMetadata`](./use-without-emitDecoratorMetadata.md) is in use and the type is set correctly, then the array type will be set automatically too.
 :::
 
 ```ts
 class Cat {
   @prop({ type: String }) // one dimensional array
   public nickNames: string[]; // array type automatically inferred because of "emitDecoratorMetadata" reflection
+
   // the above and below examples are the same
   @prop({ type: [String] }) // one dimensional array
   public nickNames: string[]; // array type automatically inferred because of "emitDecoratorMetadata" reflection
@@ -75,7 +76,7 @@ class Cat {
 
   // the "ArraySubDocumentType" type is provided by Typegoose
   @prop({ type: () => Kitten })
-  public subDocArray: ArraySubDocumentType<Kitten>; // Mongoose subdocument array, with Mongoose subdocument functions provided
+  public subDocArray: ArraySubDocumentType<Kitten>[]; // Mongoose subdocument array, with Mongoose subdocument functions provided
 }
 
 class Kitten {
@@ -99,7 +100,7 @@ class Cat {
 
   // the "ArraySubDocumentType" type is provided by Typegoose
   @prop({ type: () => Kitten })
-  public subDocArray: ArraySubDocumentType<Kitten>; // Mongoose subdocument array, with Mongoose subdocument functions provided
+  public subDocArray: ArraySubDocumentType<Kitten>[]; // Mongoose subdocument array, with Mongoose subdocument functions provided
 }
 
 class Kitten {


### PR DESCRIPTION
`ArraySubDocumentType<Kitten>` is just one Kitten subdocument, while in the context of these code samples it is meant to be an array.