### PR TITLE
docs(quick-start-guide.md): fix typo

### DIFF
--- a/docs/guides/quick-start-guide.md
+++ b/docs/guides/quick-start-guide.md
@@ -107,7 +107,7 @@ Like `public: string[]` is in reflection only `Array`.
 ### Requirements
 
 - TypeScript version `^4.9` (since 10.0) is recommended, though older ones may also work
-- NodeJS `^14.17.0` (and `@types/node@16`)
+- NodeJS `>=14.17.0` (and `@types/node@16`)
 - Mongoose `~7.4.0`
 - A IDE that supports TypeScript linting is recommended to be used (VSCode is recommended)
 - This Guide expects you to know how Mongoose (or at least its models) works


### PR DESCRIPTION
## Fix documentation for quick start guide

- Fix typo
- Update Node.js requriements to match package.json engine semver range >=14

## Fixes Issues/PR's
