### PR TITLE
feat: add support for declaring search indexes

### DIFF
--- a/docs/api/decorators/searchIndexes.md
+++ b/docs/api/decorators/searchIndexes.md
@@ -1,0 +1,79 @@
+---
+id: searchIndexes
+title: '@searchIndex'
+---
+
+**Typings:**
+
+```ts
+function searchIndex(description: SearchIndexDescription): ClassDecorator
+```
+
+**Parameters:**
+
+| Name                                                               |                                                         Type                                                         | Description                                                             |
+|:-------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------|
+| `description` <span class="badge badge--secondary">Required</span> | [`SearchIndexDescription`](https://mongodb.github.io/node-mongodb-native/6.5/interfaces/SearchIndexDescription.html) | Description of the search index, including definition and optional name |
+
+`@searchIndex` is used to set search indices on the schema, this decorator acts
+like [`schema.searchIndex()`](https://mongoosejs.com/docs/api/schema.html#Schema.prototype.searchIndex()).
+
+:::caution
+Search indices are only supported in `M10` (or higher) Mongo Atlas clusters running MongoDB 6.0+ or 7.0+. Full
+documentation
+can be found [here](https://www.mongodb.com/docs/atlas/atlas-search/manage-indexes/).
+:::
+
+:::note
+Because creating a search index can be a very heavy operation, automatic creation of search indices is disabled by
+default. To enable automatic creation of search indices,
+the [`autoSearchIndex`](https://mongoosejs.com/docs/guide.html#autoSearchIndex) option must be set to `true` in the
+schema options using the [`@modelOptions`](https://typegoose.github.io/typegoose/docs/api/decorators/model-options)
+decorator.
+:::
+
+## Example
+
+```ts
+// static search index that only maps some fields
+@searchIndex({
+  name: 'authorSearch',
+  definition: {
+    mappings: {
+      dynamic: false,
+      fields: {
+        birthday: { type: 'date' },
+        biography: { type: 'string' },
+      },
+    },
+  },
+})
+class Author {
+  @prop({ required: true })
+  public name!: string;
+
+  @prop({ required: true })
+  public birthday!: Date;
+
+  @prop({ required: true })
+  public biography!: string;
+}
+```
+
+```ts
+// dynamic index that maps all fields based on their type
+@searchIndex({ name: 'BookSearch', definition: { dynamic: true } })
+class Book {
+  @prop({ required: true })
+  public title!: string;
+
+  @prop({ required: true })
+  public author!: Ref<Author>;
+
+  @prop({ required: true })
+  public description!: string;
+
+  @prop({ required: true })
+  public publicationYear!: number;
+}
+```

--- a/docs/guides/all-decorators.md
+++ b/docs/guides/all-decorators.md
@@ -11,6 +11,7 @@ This Page shows all the decorators that can be used for / in a class.
 - All Class decorators:
   - [`@modelOptions`](../api/decorators/modelOptions.md), used for Schema Options, an existing Mongoose and an existing Connection
   - [`@index`](../api/decorators/indexes.md) is for indexes, that are **NOT** defined in the prop (mainly for compound indexes)
+  - [`@searchIndex`](../api/decorators/searchIndexes.md) is for defining a search index.
   - [`@plugin`](../api/decorators/plugin.md) is for adding plugins. Please note that plugins cannot modify the types of prop.
   - [`@queryMethod`](../api/decorators/queryMethod.md) is for adding custom query Methods.
   - [Hooks](../api/decorators/hooks.md):

--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -20,6 +20,11 @@ export enum DecoratorKeys {
    */
   Index = 'typegoose:indexes',
   /**
+   * Storage location for Search Indexes
+   * -> Use only for a class
+   */
+  SearchIndex = 'typegoose:searchIndexes',
+  /**
    * Storage location for Plugins
    * -> Use only for a class
    */

--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -12,6 +12,7 @@ import type {
   IPluginsArray,
   NestedDiscriminatorsMap,
   QueryMethodMap,
+  SearchIndexDescription,
   VirtualPopulateMap,
 } from '../types';
 import { DecoratorKeys } from './constants';
@@ -86,6 +87,19 @@ export function _buildSchema<U extends AnyParamConstructor<any>>(
       for (const index of indices) {
         logger.debug('Applying Index:', index);
         sch.index(index.fields, index.options);
+      }
+    }
+  }
+
+  {
+    /** Get Metadata for Search Indices */
+    const searchIndices: SearchIndexDescription[] = Reflect.getOwnMetadata(DecoratorKeys.SearchIndex, cl);
+    const buildSearchIndexes = typeof extraOptions?.buildSearchIndexes === 'boolean' ? extraOptions?.buildSearchIndexes : true;
+
+    if (buildSearchIndexes && Array.isArray(searchIndices)) {
+      for (const index of searchIndices) {
+        logger.debug('Applying Search Index:', index);
+        sch.searchIndex(index);
       }
     }
   }

--- a/src/searchIndexes.ts
+++ b/src/searchIndexes.ts
@@ -1,0 +1,27 @@
+import { DecoratorKeys } from './internal/constants';
+import { getName } from './internal/utils';
+import { logger } from './logSettings';
+import type { SearchIndexDescription } from './types';
+
+/**
+ * Defines a search index for this Class which will then be added to the Schema.
+ *
+ * @param description - The description of the search index to add.
+ * @example Example:
+ * ```ts
+ * @searchIndex({ name: 'descriptionIndex', definition: { mappings: { dynamic: true }}})
+ * class ClassName {}
+ * ```
+ * @remarks Search indices are only supported when connected to MongoDB Atlas.
+ */
+export function searchIndex(description: SearchIndexDescription): ClassDecorator {
+  return (target: any) => {
+    logger.info('Adding "%o" Search Indexes to %s', description, getName(target));
+    const searchIndices: SearchIndexDescription[] = Array.from(Reflect.getOwnMetadata(DecoratorKeys.SearchIndex, target) ?? []);
+    searchIndices.push(description);
+    Reflect.defineMetadata(DecoratorKeys.SearchIndex, searchIndices, target);
+  };
+}
+
+// Export it PascalCased
+export { searchIndex as SearchIndex };

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -19,8 +19,8 @@ import {
 if (typeof process !== 'undefined' && !isNullOrUndefined(process?.version) && !isNullOrUndefined(mongoose?.version)) {
   // for usage on client side
   /* istanbul ignore next */
-  if (semver.lt(mongoose?.version, '8.2.0')) {
-    throw new Error(`Please use mongoose 8.2.0 or higher (Current mongoose: ${mongoose.version}) [E001]`);
+  if (semver.lt(mongoose?.version, '8.2.4')) {
+    throw new Error(`Please use mongoose 8.2.4 or higher (Current mongoose: ${mongoose.version}) [E001]`);
   }
 
   /* istanbul ignore next */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type * as mongoose from 'mongoose';
-import type { Severity, PropType } from './internal/constants';
+import type { PropType, Severity } from './internal/constants';
 
 /**
  * Get the Type of an instance of a Document with Class properties
@@ -519,6 +519,12 @@ export interface IBuildSchemaOptions {
    * @default true
    */
   buildIndexes?: boolean;
+
+  /**
+   * Add search indexes from this class?
+   * @default true
+   */
+  buildSearchIndexes?: boolean;
 }
 
 /** Type for the Values stored in the Reflection for Properties */
@@ -532,6 +538,7 @@ export interface DecoratedPropertyMetadata {
   /** What is it for a prop type? */
   propType?: PropType;
 }
+
 export type DecoratedPropertyMetadataMap = Map<string | symbol, DecoratedPropertyMetadata>;
 
 /**
@@ -543,13 +550,22 @@ export type IndexOptions = mongoose.IndexOptions;
  * Type for the Values stored in the Reflection for Indexes
  * @example
  * ```ts
- * const indices: IIndexArray[] = Reflect.getMetadata(DecoratorKeys.Index, target) || []);
+ * const indices: IIndexArray[] = Reflect.getMetadata(DecoratorKeys.Index, target) || [];
  * ```
  */
 export interface IIndexArray {
   fields: KeyStringAny;
   options?: IndexOptions;
 }
+
+/**
+ * Type for the Values stored in the Reflection for Search Indexes
+ * @example
+ * ```ts
+ * const searchIndices: SearchIndexDescription[] = Reflect.getMetadata(DecoratorKeys.SearchIndex, target) || [];
+ * ```
+ */
+export type SearchIndexDescription = mongoose.SearchIndexDescription;
 
 /**
  * Type for the Values stored in the Reflection for Plugins

--- a/test/models/book.ts
+++ b/test/models/book.ts
@@ -1,0 +1,31 @@
+import { prop } from '../../src/prop';
+import { searchIndex } from '../../src/searchIndexes';
+import { getModelForClass, modelOptions } from '../../src/typegoose';
+
+@searchIndex({
+  name: 'descriptionIndex',
+  definition: {
+    mappings: {
+      dynamic: false,
+      fields: {
+        description: { type: 'string' },
+      },
+    },
+  },
+})
+@modelOptions({ schemaOptions: { autoSearchIndex: true } })
+export class Book {
+  @prop({ required: true })
+  public title!: string;
+
+  @prop({ required: true })
+  public author!: string;
+
+  @prop({ required: true })
+  public description!: string;
+
+  @prop({ required: true })
+  public publicationYear!: number;
+}
+
+export const BookModel = getModelForClass(Book);

--- a/test/tests/searchIndexes.test.ts
+++ b/test/tests/searchIndexes.test.ts
@@ -1,0 +1,22 @@
+import { Book } from '../models/book';
+import { buildSchema } from '../../src/typegoose';
+
+it('should add a search index', async () => {
+  const schema = buildSchema(Book);
+
+  expect(schema.indexes()).toEqual([]);
+  // @ts-expect-error use the private property because there is no method to fetch search indexes yet
+  expect(schema._searchIndexes).toEqual([
+    {
+      name: 'descriptionIndex',
+      definition: {
+        mappings: {
+          dynamic: false,
+          fields: {
+            description: { type: 'string' },
+          },
+        },
+      },
+    },
+  ]);
+});

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -6,6 +6,7 @@ module.exports = {
       'api/decorators/model-options',
       'api/decorators/hooks',
       'api/decorators/indexes',
+      'api/decorators/searchIndexes',
       'api/decorators/plugin',
       'api/decorators/query-method',
     ],


### PR DESCRIPTION
MongoDB and `mongoose` now support adding search indexes to collections. Introduce a new decorator `@searchIndex()` that, similar to `@index`, adds a search index to a collection.

Search index support was added to `mongoose` in version `8.1.0`, however the type definition for `Schema.searchIndex()` didn't exist until `8.2.3`. Therefore in order to support this feature, update the `mongoose` dependencies to `~8.2.3`.

## Related Issues

- N/A
