### PR TITLE
fix(searchindex): search index wasn't exported

### DIFF
--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -56,6 +56,7 @@ export * from './prop';
 export * from './hooks';
 export * from './plugin';
 export * from './indexes';
+export * from './searchIndexes';
 export * from './modelOptions';
 export * from './queryMethod';
 export * from './typeguards';


### PR DESCRIPTION
The search index decorator (`@searchIndex()`) was added in `v12.3.0` in PR #921 but I neglected to actually export the decorator so it isn't currently available for use.

## Related Issues

- N/A
